### PR TITLE
Change http-conduit version to be able to compile.

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -148,7 +148,7 @@ Library
                  old-locale,
                  HTTP,
                  network,
-                 http-conduit == 1.4.1.10,
+                 http-conduit >= 1.8,
                  conduit,
                  uri,
                  failure,


### PR DESCRIPTION
Hi,

I changed http-conduit version, because I can't cabal install github for dependency problem.

By the way, this library on github is version 0.3.0, but the one on hackage is version 0.4.0.
So if there are some changes at version 0.4.0, can you push?
