### PR TITLE
uri package is unused, remove its dependency.

### DIFF
--- a/Github/Private.hs
+++ b/Github/Private.hs
@@ -11,7 +11,6 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import Network.HTTP.Types (Method, Status(..))
 import Network.HTTP.Conduit
 import Data.Conduit (ResourceT)
-import Text.URI
 import qualified Control.Exception as E
 import Data.Maybe (fromMaybe)
 

--- a/github.cabal
+++ b/github.cabal
@@ -150,7 +150,6 @@ Library
                  network,
                  http-conduit >= 1.8,
                  conduit,
-                 uri,
                  failure,
                  http-types,
                  data-default,


### PR DESCRIPTION
Prompted by a discussion on libraries@haskell.org about splitting the network
package: http://www.haskell.org/pipermail/libraries/2013-January/019251.html

The github package does not actually use any functions or types from Text.URI;
this patch simply removes the package dependency and the redundant Text.URI
import.
