### PR TITLE
Changed the types of the githubOwnerGravatarId and detailedOwnerGravatar...

### DIFF
--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -60,7 +60,7 @@ data GithubOwner = GithubUser {
   ,githubOwnerLogin :: String
   ,githubOwnerUrl :: String
   ,githubOwnerId :: Int
-  ,githubOwnerGravatarId :: String
+  ,githubOwnerGravatarId :: Maybe String
   }
   | GithubOrganization {
    githubOwnerAvatarUrl :: String
@@ -434,7 +434,7 @@ data DetailedOwner = DetailedUser {
   ,detailedOwnerFollowers :: Int
   ,detailedOwnerFollowing :: Int
   ,detailedOwnerHireable :: Bool
-  ,detailedOwnerGravatarId :: String
+  ,detailedOwnerGravatarId :: Maybe String
   ,detailedOwnerBlog :: Maybe String
   ,detailedOwnerBio :: Maybe String
   ,detailedOwnerPublicRepos :: Int


### PR DESCRIPTION
I've changed the types of the githubOwnerGravatarId and detailedOwnerGravatarId fields in Definitions.hs from String to Maybe String, so as to avoid problems with Null values being returned. 
