### PR TITLE
add starring interface

### DIFF
--- a/Github/Repos/Starring.hs
+++ b/Github/Repos/Starring.hs
@@ -1,0 +1,29 @@
+-- | The repo starring API as described on
+-- <http://developer.github.com/v3/repos/starring/>.
+module Github.Repos.Starring (
+ stargazersFor
+,reposStarredBy
+,myStarred
+,module Github.Data
+) where
+
+import Github.Data
+import Github.Data.Definitions
+import Github.Private
+
+-- | The list of users that have starred the specified Github repo.
+--
+-- > userInfoFor' Nothing "mike-burns"
+stargazersFor :: Maybe GithubAuth -> String -> String -> IO (Either Error [GithubOwner])
+stargazersFor auth userName repoName =
+  githubGet' auth ["repos", userName, repoName, "stargazers"]
+
+-- | All the public repos starred by the specified user.
+--
+-- > reposStarredBy Nothing "croaky"
+reposStarredBy :: Maybe GithubAuth -> String -> IO (Either Error [Repo])
+reposStarredBy auth userName = githubGet' auth ["users", userName, "starred"]
+
+-- | All the repos starred by the authenticated user.
+myStarred :: GithubAuth -> IO (Either Error [Repo])
+myStarred auth = githubGet' (Just auth) ["user", "starred"]

--- a/github.cabal
+++ b/github.cabal
@@ -96,6 +96,7 @@ Extra-source-files:  README.md
                     ,samples/Repos/ShowRepo.hs
                     ,samples/Repos/Watching/ListWatched.hs
                     ,samples/Repos/Watching/ListWatchers.hs
+                    ,samples/Repos/Starring/ListStarred.hs
                     ,samples/Users/Followers/ListFollowers.hs
                     ,samples/Users/Followers/ListFollowing.hs
                     ,samples/Users/ShowUser.hs
@@ -134,6 +135,7 @@ Library
                    Github.Repos.Commits,
                    Github.Repos.Forks,
                    Github.Repos.Watching,
+                   Github.Repos.Starring,
                    Github.Users,
                    Github.Users.Followers
 

--- a/samples/Repos/Starring/ListStarred.hs
+++ b/samples/Repos/Starring/ListStarred.hs
@@ -1,0 +1,24 @@
+module ListStarred where
+
+import qualified Github.Repos.Starring as Github
+import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
+
+main = do
+  possibleRepos <- Github.reposStarredBy Nothing "mike-burns"
+  putStrLn $ either (("Error: "++) . show)
+                    (intercalate "\n\n" . map formatRepo)
+                    possibleRepos
+
+formatRepo repo =
+  (Github.repoName repo) ++ "\t" ++
+    (fromMaybe "" $ Github.repoDescription repo) ++ "\n" ++
+    (Github.repoHtmlUrl repo) ++ "\n" ++
+    (Github.repoCloneUrl repo) ++ "\t" ++
+    (formatDate $ Github.repoUpdatedAt repo) ++ "\n" ++
+    formatLanguage (Github.repoLanguage repo)
+
+formatDate = show . Github.fromGithubDate
+
+formatLanguage (Just language) = "language: " ++ language ++ "\t"
+formatLanguage Nothing = ""


### PR DESCRIPTION
Since these are new functions, I made them all take a Maybe GithubAuth.

Only implemented the parts I need, which does not include the api to
star and unstar a repository, or check if a single repository is starred
by the authed user.
