### PR TITLE
add repoParent and repoSource fields

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -425,7 +425,14 @@ instance FromJSON Repo where
          <*> o .:? "has_wiki"
          <*> o .:? "has_issues"
          <*> o .:? "has_downloads"
+	 <*> o .:? "parent"
+	 <*> o .:? "source"
   parseJSON _ = fail "Could not build a Repo"
+
+instance FromJSON RepoRef where
+  parseJSON (Object o) =
+    RepoRef <$> o .: "owner"
+            <*> o .: "name"
 
 instance FromJSON Contributor where
   parseJSON (Object o)

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -390,7 +390,12 @@ data Repo = Repo {
   ,repoHasWiki :: Maybe Bool
   ,repoHasIssues :: Maybe Bool
   ,repoHasDownloads :: Maybe Bool
+  ,repoParent :: Maybe RepoRef
+  ,repoSource :: Maybe RepoRef
 } deriving (Show, Data, Typeable, Eq, Ord)
+
+data RepoRef = RepoRef GithubOwner String -- Repo owner and name
+ deriving (Show, Data, Typeable, Eq, Ord)
 
 data Contributor
   -- | An existing Github user, with their number of contributions, avatar


### PR DESCRIPTION
These are populated with the repo that it was forked from, and the top repo
in the graph, respectively. This works when using userRepo to get a Repo.

Note that repoParent and repoSource are RepoRef and not Repo because the
API only returns an abbreviated object for these, not sufficient to
construct a full repo.

Closes https://github.com/fpco/github/issues/43
