### PR TITLE
Support parsing pull request details where mergeable is null

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -382,7 +382,7 @@ instance FromJSON DetailedPullRequest where
         <*> o .: "base"
         <*> o .: "commits"
         <*> o .: "merged"
-        <*> o .: "mergeable"
+        <*> o .:? "mergeable"
   parseJSON _ = fail "Could not build a DetailedPullRequest"
 
 instance FromJSON PullRequestLinks where

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -351,7 +351,7 @@ data DetailedPullRequest = DetailedPullRequest {
   ,detailedPullRequestBase :: PullRequestCommit
   ,detailedPullRequestCommits :: Int
   ,detailedPullRequestMerged :: Bool
-  ,detailedPullRequestMergeable :: Bool
+  ,detailedPullRequestMergeable :: Maybe Bool
 } deriving (Show, Data, Typeable, Eq, Ord)
 
 data PullRequestLinks = PullRequestLinks {


### PR DESCRIPTION
I believe this field is set to null if the PR has already been merged.
