### PR TITLE
Fix GitTree parsing on submodule paths

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -48,7 +48,7 @@ instance FromJSON GitTree where
   parseJSON (Object o) =
     GitTree <$> o .: "type"
          <*> o .: "sha"
-         <*> o .: "url"
+         <*> o .:? "url"
          <*> o .:? "size"
          <*> o .: "path"
          <*> o .: "mode"

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -39,7 +39,8 @@ data Tree = Tree {
 data GitTree = GitTree {
   gitTreeType :: String
   ,gitTreeSha :: String
-  ,gitTreeUrl :: String
+  -- Can be empty for submodule
+  ,gitTreeUrl :: Maybe String
   ,gitTreeSize :: Maybe Int
   ,gitTreePath :: String
   ,gitTreeMode :: String


### PR DESCRIPTION
This is unfortunate, but otherwise you can't look at the tree that contains a submodule. :(
