### PR TITLE
Add the missing actions for PullRequestEventType

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -416,6 +416,10 @@ instance FromJSON PullRequestEventType where
   parseJSON (String "closed") = pure PullRequestClosed
   parseJSON (String "synchronize") = pure PullRequestSynchronized
   parseJSON (String "reopened") = pure PullRequestReopened
+  parseJSON (String "assigned") = pure PullRequestAssigned
+  parseJSON (String "unassigned") = pure PullRequestUnassigned
+  parseJSON (String "labeled") = pure PullRequestLabeled
+  parseJSON (String "unlabeled") = pure PullRequestUnlabeled
   parseJSON _ = fail "Could not build a PullRequestEventType"
 
 instance FromJSON PingEvent where

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -532,6 +532,10 @@ data PullRequestEventType =
   | PullRequestClosed
   | PullRequestSynchronized
   | PullRequestReopened
+  | PullRequestAssigned
+  | PullRequestUnassigned
+  | PullRequestLabeled
+  | PullRequestUnlabeled
   deriving (Show, Data, Typeable, Eq, Ord)
 
 data PingEvent = PingEvent {


### PR DESCRIPTION
From the official Github API's docs:

```
Key         Type        Description
action      string        The action that was performed. Can be one of “assigned”, “unassigned”, “labeled”, “unlabeled”, “opened”, “closed”, or “reopened”, or “synchronize”. If the action is “closed” and the merged key is false, the pull request was closed with unmerged commits. If the action is “closed” and the merged key is true, the pull request was merged.
```

so I just added the ones that were missing.
