### PR TITLE
Use variant type to represent webhook events.

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -432,6 +432,51 @@ instance FromJSON PullRequestEventType where
   parseJSON (String "unlabeled") = pure PullRequestUnlabeled
   parseJSON _ = fail "Could not build a PullRequestEventType"
 
+instance FromJSON RepoWebhookEvent where
+  parseJSON (String "*") = pure WebhookWildcardEvent
+  parseJSON (String "commit_comment") = pure WebhookCommitCommentEvent
+  parseJSON (String "create") = pure WebhookCreateEvent
+  parseJSON (String "delete") = pure WebhookDeleteEvent
+  parseJSON (String "deployment") = pure WebhookDeploymentEvent
+  parseJSON (String "deployment_status") = pure WebhookDeploymentStatusEvent
+  parseJSON (String "fork") = pure WebhookForkEvent
+  parseJSON (String "gollum") = pure WebhookGollumEvent
+  parseJSON (String "issue_comment") = pure WebhookIssueCommentEvent
+  parseJSON (String "issues") = pure WebhookIssuesEvent
+  parseJSON (String "member") = pure WebhookMemberEvent
+  parseJSON (String "page_build") = pure WebhookPageBuildEvent
+  parseJSON (String "public") = pure WebhookPublicEvent
+  parseJSON (String "pull_request_review_comment") = pure WebhookPullRequestReviewCommentEvent
+  parseJSON (String "pull_request") = pure WebhookPullRequestEvent
+  parseJSON (String "push") = pure WebhookPushEvent
+  parseJSON (String "release") = pure WebhookReleaseEvent
+  parseJSON (String "status") = pure WebhookStatusEvent
+  parseJSON (String "team_add") = pure WebhookTeamAddEvent
+  parseJSON (String "watch") = pure WebhookWatchEvent
+  parseJSON _ = fail "Could not build a Webhook event"
+
+instance ToJSON RepoWebhookEvent where
+  toJSON (WebhookWildcardEvent) = String "*"
+  toJSON (WebhookCommitCommentEvent) = String "commit_comment"
+  toJSON (WebhookCreateEvent) = String "create"
+  toJSON (WebhookDeleteEvent) = String "delete"
+  toJSON (WebhookDeploymentEvent) = String "deployment"
+  toJSON (WebhookDeploymentStatusEvent) = String "deployment_status"
+  toJSON (WebhookForkEvent) = String "fork"
+  toJSON (WebhookGollumEvent) = String "gollum"
+  toJSON (WebhookIssueCommentEvent) = String "issue_comment"
+  toJSON (WebhookIssuesEvent) = String "issues"
+  toJSON (WebhookMemberEvent) = String "member"
+  toJSON (WebhookPageBuildEvent) = String "page_build"
+  toJSON (WebhookPublicEvent) = String "public"
+  toJSON (WebhookPullRequestReviewCommentEvent) = String "pull_request_review_comment"
+  toJSON (WebhookPullRequestEvent) = String "pull_request"
+  toJSON (WebhookPushEvent) = String "push"
+  toJSON (WebhookReleaseEvent) = String "release"
+  toJSON (WebhookStatusEvent) = String "status"
+  toJSON (WebhookTeamAddEvent) = String "team_add"
+  toJSON (WebhookWatchEvent) = String "watch"
+
 instance FromJSON PingEvent where
   parseJSON (Object o) =
     PingEvent <$> o .: "zen"

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -512,12 +512,35 @@ data RepoWebhook = RepoWebhook {
   ,repoWebhookId :: Integer
   ,repoWebhookName :: String
   ,repoWebhookActive :: Bool
-  ,repoWebhookEvents :: [String]
+  ,repoWebhookEvents :: [RepoWebhookEvent]
   ,repoWebhookConfig :: M.Map String String
   ,repoWebhookLastResponse :: RepoWebhookResponse
   ,repoWebhookUpdatedAt :: GithubDate
   ,repoWebhookCreatedAt :: GithubDate
 } deriving (Show, Data, Typeable, Eq, Ord)
+
+data RepoWebhookEvent =
+   WebhookWildcardEvent
+ | WebhookCommitCommentEvent
+ | WebhookCreateEvent
+ | WebhookDeleteEvent
+ | WebhookDeploymentEvent
+ | WebhookDeploymentStatusEvent
+ | WebhookForkEvent
+ | WebhookGollumEvent
+ | WebhookIssueCommentEvent
+ | WebhookIssuesEvent
+ | WebhookMemberEvent
+ | WebhookPageBuildEvent
+ | WebhookPublicEvent
+ | WebhookPullRequestReviewCommentEvent
+ | WebhookPullRequestEvent
+ | WebhookPushEvent
+ | WebhookReleaseEvent
+ | WebhookStatusEvent
+ | WebhookTeamAddEvent
+ | WebhookWatchEvent
+   deriving (Show, Data, Typeable, Eq, Ord)
 
 data RepoWebhookResponse = RepoWebhookResponse {
    repoWebhookResponseCode :: Maybe Int

--- a/Github/Repos/Webhooks.hs
+++ b/Github/Repos/Webhooks.hs
@@ -39,19 +39,19 @@ import Data.Aeson
 type RepoOwner = String
 type RepoName = String
 type RepoWebhookId = Int
-
+    
 data NewRepoWebhook = NewRepoWebhook {
   newRepoWebhookName :: String
  ,newRepoWebhookConfig :: M.Map String String
- ,newRepoWebhookEvents :: Maybe [String]
+ ,newRepoWebhookEvents :: Maybe [RepoWebhookEvent]
  ,newRepoWebhookActive :: Maybe Bool
 } deriving Show
 
 data EditRepoWebhook = EditRepoWebhook {
   editRepoWebhookConfig :: Maybe (M.Map String String)
- ,editRepoWebhookEvents :: Maybe [String]
- ,editRepoWebhookAddEvents :: Maybe [String]
- ,editRepoWebhookRemoveEvents :: Maybe [String]
+ ,editRepoWebhookEvents :: Maybe [RepoWebhookEvent]
+ ,editRepoWebhookAddEvents :: Maybe [RepoWebhookEvent]
+ ,editRepoWebhookRemoveEvents :: Maybe [RepoWebhookEvent]
  ,editRepoWebhookActive :: Maybe Bool
 } deriving Show
                   

--- a/samples/Repos/Webhooks/CreateWebhook.hs
+++ b/samples/Repos/Webhooks/CreateWebhook.hs
@@ -12,7 +12,7 @@ main = do
   let webhookDef = NewRepoWebhook {
         newRepoWebhookName = "web",
         newRepoWebhookConfig = config,
-        newRepoWebhookEvents = Just ["*"],
+        newRepoWebhookEvents = Just [WebhookWildcardEvent],
         newRepoWebhookActive = Just True
       }
   newWebhook <- createRepoWebhook' auth "repoOwner" "repoName" webhookDef

--- a/samples/Repos/Webhooks/EditWebhook.hs
+++ b/samples/Repos/Webhooks/EditWebhook.hs
@@ -8,8 +8,8 @@ main :: IO ()
 main = do
   let auth = Auth.GithubOAuth "oauthtoken"
   let editWebhookDef = EditRepoWebhook {
-        editRepoWebhookRemoveEvents = Just ["*"],
-        editRepoWebhookAddEvents = Just ["commit_comment"],
+        editRepoWebhookRemoveEvents = Just [WebhookWildcardEvent],
+        editRepoWebhookAddEvents = Just [WebhookCommitCommentEvent, WebhookGollumEvent],
         editRepoWebhookConfig = Nothing,
         editRepoWebhookEvents = Nothing,
         editRepoWebhookActive = Just True


### PR DESCRIPTION
I made the mistake of using String to represent the webhook events when a nice variant type is the perfect match. I am fixing my bad decision. It makes it more discoverable imho.

The docs about the different webhook events is available here: https://developer.github.com/webhooks/#events

@maxpow4h what do you think?
