### PR TITLE
Add missing issue event types.

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -207,6 +207,7 @@ instance FromJSON Issue where
   parseJSON (Object o) =
     Issue <$> o .:? "closed_at"
           <*> o .: "updated_at"
+          <*> o .: "events_url"
           <*> o .: "html_url"
           <*> o .:? "closed_by"
           <*> o .: "labels"
@@ -302,6 +303,16 @@ instance FromJSON EventType where
   parseJSON (String "mentioned") = pure Mentioned
   parseJSON (String "assigned") = pure Assigned
   parseJSON (String "unsubscribed") = pure Unsubscribed
+  parseJSON (String "unassigned") = pure ActorUnassigned
+  parseJSON (String "labeled") = pure Labeled
+  parseJSON (String "unlabeled") = pure Unlabeled
+  parseJSON (String "milestoned") = pure Milestoned
+  parseJSON (String "demilestoned") = pure Demilestoned
+  parseJSON (String "renamed") = pure Renamed
+  parseJSON (String "locked") = pure Locked
+  parseJSON (String "unlocked") = pure Unlocked
+  parseJSON (String "head_ref_deleted") = pure HeadRefDeleted
+  parseJSON (String "head_ref_restored") = pure HeadRefRestored
   parseJSON _ = fail "Could not build an EventType"
 
 instance FromJSON SimpleOrganization where

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -188,6 +188,7 @@ data GitObject = GitObject {
 data Issue = Issue {
    issueClosedAt :: Maybe GithubDate
   ,issueUpdatedAt :: GithubDate
+  ,issueEventsUrl :: String
   ,issueHtmlUrl :: Maybe String
   ,issueClosedBy :: Maybe GithubOwner
   ,issueLabels :: [IssueLabel]
@@ -267,6 +268,16 @@ data EventType =
   | Assigned      -- ^ The issue was assigned to the actor.
   | Closed        -- ^ The issue was closed by the actor. When the commit_id is present, it identifies the commit that closed the issue using “closes / fixes #NN” syntax. 
   | Reopened      -- ^ The issue was reopened by the actor.
+  | ActorUnassigned    -- ^ The issue was unassigned to the actor
+  | Labeled       -- ^ A label was added to the issue.
+  | Unlabeled     -- ^ A label was removed from the issue.
+  | Milestoned    -- ^ The issue was added to a milestone.
+  | Demilestoned  -- ^ The issue was removed from a milestone.
+  | Renamed       -- ^ The issue title was changed.
+  | Locked        -- ^ The issue was locked by the actor.
+  | Unlocked      -- ^ The issue was unlocked by the actor.
+  | HeadRefDeleted -- ^ The pull request’s branch was deleted.
+  | HeadRefRestored -- ^ The pull request’s branch was restored.
   deriving (Show, Data, Typeable, Eq, Ord)
 
 data Event = Event {

--- a/github.cabal
+++ b/github.cabal
@@ -7,7 +7,7 @@ Name:                github
 -- The package version. See the Haskell package versioning policy
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy) for
 -- standards guiding when and how versions should be incremented.
-Version:             0.9
+Version:             0.10.0
 
 -- A short (one-line) description of the package.
 Synopsis:            Access to the Github API, v3.


### PR DESCRIPTION
I am using the events API and noticed that we were missing some new data constructors so I added them. 

I bumped the major version as per:

``````
If any entity was removed, or the types of any entities or the definitions of datatypes or classes were changed, or orphan instances were added or any instances were removed, then the new A.B must be greater than the previous A.B. Note that modifying imports or depending on a newer version of another package may cause extra orphan instances to be exported and thus force a major version change.```
per [Haskell's Package Version Policy](http://www.haskell.org/haskellwiki/Package_versioning_policy).
``````

@maxpow4h Good to go?
