### PR TITLE
Add a function for validating payloads from GitHub webhooks

### DIFF
--- a/Github/Repos/Webhooks/Validate.hs
+++ b/Github/Repos/Webhooks/Validate.hs
@@ -1,0 +1,26 @@
+-- | Verification of incomming webhook payloads, as described at
+-- <https://developer.github.com/webhooks/securing/>
+
+module Github.Repos.Webhooks.Validate (
+  isValidPayload
+) where
+
+import Crypto.Hash
+import qualified Data.ByteString.Char8 as BS
+
+
+-- | Validates a given payload against a given HMAC hexdigest using a given
+-- secret.
+-- Returns 'True' iff the given hash is non-empty and it's a valid signature of
+-- the payload.
+isValidPayload
+  :: String             -- ^ the secret
+  -> Maybe String       -- ^ the hash provided by the remote party
+                        -- in @X-Hub-Signature@ (if any),
+                        -- including the 'sha1=...' prefix
+  -> BS.ByteString      -- ^ the body
+  -> Bool
+isValidPayload secret shaOpt payload = Just sign == shaOpt
+  where
+    hm = hmac (BS.pack secret) payload :: HMAC SHA1
+    sign = "sha1=" ++ (show . hmacGetDigest $ hm)

--- a/github.cabal
+++ b/github.cabal
@@ -145,6 +145,7 @@ Library
                    Github.Repos.Watching,
                    Github.Repos.Starring,
                    Github.Repos.Webhooks
+                   Github.Repos.Webhooks.Validate,
                    Github.Users,
                    Github.Users.Followers
                    Github.Search
@@ -168,7 +169,8 @@ Library
                  http-types,
                  data-default,
                  vector,
-                 unordered-containers >= 0.2 && < 0.3
+                 unordered-containers >= 0.2 && < 0.3,
+                 cryptohash >= 0.11
 
   -- Modules not exported by this package.
   Other-modules:       Github.Private


### PR DESCRIPTION
Given a GitHub secret, a payload and the signature delivered with the
payload in `X-Hub-Signature`, verifies if the signature is valid or not.
See issue #76.

---

I wasn't sure what sample would you prefer for this, if any, as a working sample needs some kind of a web server. I could provide a sample application with [scotty](https://hackage.haskell.org/package/scotty) (around 20 lines of code), but it won't work without additional dependencies.
