### PR TITLE
Validation: Guard against timing attacks. Improves #76 and #77.

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -170,7 +170,9 @@ Library
                  data-default,
                  vector,
                  unordered-containers >= 0.2 && < 0.3,
-                 cryptohash >= 0.11
+                 cryptohash >= 0.11,
+                 byteable >= 0.1.0,
+                 base16-bytestring >= 0.1.1.6
 
   -- Modules not exported by this package.
   Other-modules:       Github.Private


### PR DESCRIPTION
The check asked for in #76 and implemented in #77 uses non-constant time comparison to check the checksum supplied by Github.

From https://developer.github.com/webhooks/securing:

  Using a plain == operator is **not advised**.
  A method like `secure_compare` performs a "constant time" string
  comparison, which renders it safe from certain timing attacks against
  regular equality operators.
