### PR TITLE
Make searches paginated

### DIFF
--- a/samples/Search/SearchCode.hs
+++ b/samples/Search/SearchCode.hs
@@ -1,30 +1,31 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module SearchCode where
+module Main where
 
-import qualified Github as Github
+import qualified GitHub
 import Control.Monad (forM_)
 import Data.List (intercalate)
+import qualified Data.Text as T
 
 main :: IO ()
 main = do
-  let query = "q=Code repo:jwiegley/github&per_page=100"
-  result <- Github.github' Github.searchCodeR query 1000
+  let query = "Code repo:haskell-github/github"
+  result <- GitHub.github' GitHub.searchCodeR query 1000
   case result of
     Left e  -> putStrLn $ "Error: " ++ show e
     Right r -> do
-      forM_ (Github.searchResultResults r) $ \r -> do
+      forM_ (GitHub.searchResultResults r) $ \r -> do
         putStrLn $ formatCode r
         putStrLn ""
-      putStrLn $ "Count: " ++ show (Github.searchResultTotalCount r)
+      putStrLn $ "Count: " ++ show (GitHub.searchResultTotalCount r)
         ++ " matches for the query: \"" ++ T.unpack query ++ "\""
 
-formatCode :: Github.Code -> String
+formatCode :: GitHub.Code -> String
 formatCode r =
-  let fields = [ ("Name", show . Github.codeName)
-               , ("Path", show . Github.codePath)
-               , ("Sha",  show . Github.codeSha)
-               , ("URL",  show . Github.codeHtmlUrl)
+  let fields = [ ("Name", show . GitHub.codeName)
+               , ("Path", show . GitHub.codePath)
+               , ("Sha",  show . GitHub.codeSha)
+               , ("URL",  show . GitHub.codeHtmlUrl)
                ]
   in intercalate "\n" $ map fmt fields
     where fmt (s,f) = fill 12 (s ++ ":") ++ " " ++ f r

--- a/samples/Search/SearchCode.hs
+++ b/samples/Search/SearchCode.hs
@@ -3,7 +3,6 @@
 module SearchCode where
 
 import qualified Github as Github
-import qualified Github as Github
 import Control.Monad (forM_)
 import Data.List (intercalate)
 

--- a/samples/Search/SearchCode.hs
+++ b/samples/Search/SearchCode.hs
@@ -1,34 +1,33 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module SearchCode where
 
-import qualified Github.Search as Github
-import qualified Github.Data as Github
-import Control.Monad (forM,forM_)
-import Data.Maybe (fromMaybe)
+import qualified Github as Github
+import qualified Github as Github
+import Control.Monad (forM_)
 import Data.List (intercalate)
 
+main :: IO ()
 main = do
   let query = "q=Code repo:jwiegley/github&per_page=100"
-  let auth = Nothing
-  result <- Github.searchCode' auth query
+  result <- Github.github' Github.searchCodeR query 1000
   case result of
     Left e  -> putStrLn $ "Error: " ++ show e
-    Right r -> do forM_ (Github.searchCodeCodes r) (\r -> do
-                    putStrLn $ formatCode r
-                    putStrLn ""
-                    )
-                  putStrLn $ "Count: " ++ show n ++ " matches for the query: \"" ++ query ++ "\""
-      where n = Github.searchCodeTotalCount r
+    Right r -> do
+      forM_ (Github.searchResultResults r) $ \r -> do
+        putStrLn $ formatCode r
+        putStrLn ""
+      putStrLn $ "Count: " ++ show (Github.searchResultTotalCount r)
+        ++ " matches for the query: \"" ++ T.unpack query ++ "\""
 
 formatCode :: Github.Code -> String
 formatCode r =
-  let fields = [ ("Name", Github.codeName)
-                 ,("Path",  Github.codePath)
-                 ,("Sha", Github.codeSha)
-                 ,("URL", Github.codeHtmlUrl)
+  let fields = [ ("Name", show . Github.codeName)
+               , ("Path", show . Github.codePath)
+               , ("Sha",  show . Github.codeSha)
+               , ("URL",  show . Github.codeHtmlUrl)
                ]
   in intercalate "\n" $ map fmt fields
     where fmt (s,f) = fill 12 (s ++ ":") ++ " " ++ f r
           fill n s = s ++ replicate n' ' '
             where n' = max 0 (n - length s) 
-

--- a/samples/Search/SearchIssues.hs
+++ b/samples/Search/SearchIssues.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module SearchIssues where
 
-import qualified Github.Search as Github
+import qualified Github as Github
 import qualified Data.Text as T
 import Control.Monad (forM_)
 

--- a/samples/Search/SearchIssues.hs
+++ b/samples/Search/SearchIssues.hs
@@ -2,25 +2,27 @@
 module SearchIssues where
 
 import qualified Github.Search as Github
+import qualified Data.Text as T
 import Control.Monad (forM_)
 
+main :: IO ()
 main = do
   let query = "q=build%20repo%3Aphadej%2Fgithub&per_page=100"
-  let auth = Nothing
-  result <- Github.searchIssues' auth query
+  result <- Github.github' Github.searchIssuesR query 1000
   case result of
     Left e  -> putStrLn $ "Error: " ++ show e
-    Right r -> do forM_ (Github.searchIssuesIssues r) (\i -> do
-                    putStrLn $ formatIssue i
-                    putStrLn ""
-                    )
-                  putStrLn $ "Count: " ++ show n ++ " build issues"
-      where n = Github.searchIssuesTotalCount r
+    Right r -> do
+      forM_ (Github.searchResultResults r) $ \r -> do
+        putStrLn $ formatIssue r
+        putStrLn ""
+      putStrLn $ "Count: " ++ show (Github.searchResultTotalCount r)
+        ++ " matches for the query: \"" ++ T.unpack query ++ "\""
 
+formatIssue :: Github.Issue -> String
 formatIssue issue =
-  (Github.githubOwnerLogin $ Github.issueUser issue) ++
-    " opened this issue " ++
-    (show $ Github.fromDate $ Github.issueCreatedAt issue) ++ "\n" ++
-    (Github.issueState issue) ++ " with " ++
-    (show $ Github.issueComments issue) ++ " comments" ++ "\n\n" ++
-    (Github.issueTitle issue)
+  (show $ Github.issueUser issue) <>
+    " opened this issue " <>
+    (show $ Github.issueCreatedAt issue) <> "\n" <>
+    (show $ Github.issueState issue) <> " with " <>
+    (show $ Github.issueComments issue) <> " comments" <> "\n\n" <>
+    (T.unpack $ Github.issueTitle issue)

--- a/samples/Search/SearchIssues.hs
+++ b/samples/Search/SearchIssues.hs
@@ -1,28 +1,28 @@
 {-# LANGUAGE OverloadedStrings #-}
-module SearchIssues where
+module Main where
 
-import qualified Github as Github
+import qualified GitHub
 import qualified Data.Text as T
 import Control.Monad (forM_)
 
 main :: IO ()
 main = do
-  let query = "q=build%20repo%3Aphadej%2Fgithub&per_page=100"
-  result <- Github.github' Github.searchIssuesR query 1000
+  let query = "build repo:haskell-github/github"
+  result <- GitHub.github' GitHub.searchIssuesR query 1000
   case result of
     Left e  -> putStrLn $ "Error: " ++ show e
     Right r -> do
-      forM_ (Github.searchResultResults r) $ \r -> do
+      forM_ (GitHub.searchResultResults r) $ \r -> do
         putStrLn $ formatIssue r
         putStrLn ""
-      putStrLn $ "Count: " ++ show (Github.searchResultTotalCount r)
+      putStrLn $ "Count: " ++ show (GitHub.searchResultTotalCount r)
         ++ " matches for the query: \"" ++ T.unpack query ++ "\""
 
-formatIssue :: Github.Issue -> String
+formatIssue :: GitHub.Issue -> String
 formatIssue issue =
-  (show $ Github.issueUser issue) <>
+  (show $ GitHub.issueUser issue) <>
     " opened this issue " <>
-    (show $ Github.issueCreatedAt issue) <> "\n" <>
-    (show $ Github.issueState issue) <> " with " <>
-    (show $ Github.issueComments issue) <> " comments" <> "\n\n" <>
-    (T.unpack $ Github.issueTitle issue)
+    (show $ GitHub.issueCreatedAt issue) <> "\n" <>
+    (show $ GitHub.issueState issue) <> " with " <>
+    (show $ GitHub.issueComments issue) <> " comments" <> "\n\n" <>
+    (T.unpack $ GitHub.issueTitle issue)

--- a/samples/Search/SearchIssues.hs
+++ b/samples/Search/SearchIssues.hs
@@ -4,6 +4,7 @@ module Main where
 import qualified GitHub
 import qualified Data.Text as T
 import Control.Monad (forM_)
+import Data.Monoid ((<>))
 
 main :: IO ()
 main = do

--- a/samples/Search/SearchRepos.hs
+++ b/samples/Search/SearchRepos.hs
@@ -4,6 +4,7 @@ module Main where
 import qualified GitHub
 import Control.Monad (forM_)
 import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
 import Data.List (intercalate)
 import System.Environment (getArgs)
 import Text.Printf (printf)

--- a/samples/Search/SearchRepos.hs
+++ b/samples/Search/SearchRepos.hs
@@ -1,49 +1,51 @@
 {-# LANGUAGE OverloadedStrings #-}
-module SearchRepos where
+module Main where
 
-import qualified Github as Github
-import Control.Monad (forM,forM_)
+import qualified GitHub
+import Control.Monad (forM_)
 import Data.Maybe (fromMaybe)
 import Data.List (intercalate)
 import System.Environment (getArgs)
 import Text.Printf (printf)
 import Data.Time.Clock (getCurrentTime, UTCTime(..))
-import Data.Time.LocalTime (utc,utcToLocalTime,localDay,localTimeOfDay,TimeOfDay(..))
+import Data.Time.LocalTime (utc,utcToLocalTime,localDay)
 import Data.Time.Calendar (toGregorian)
+import Data.Text (Text)
+import qualified Data.Text as T
 
 main :: IO ()
 main = do
   args <- getArgs
   date <- case args of
-            (x:_)     -> return x
-            otherwise -> today
-  let query = "q=language%3Ahaskell created%3A>" ++ date ++ "&per_page=100"
-  result <- Github.github' Github.searchReposR query 1000
+            (x:_)     -> return $ T.pack x
+            _ -> today
+  let query = ("language:haskell created:>" <> date) :: Text
+  result <- GitHub.github' GitHub.searchReposR query 1000
   case result of
     Left e  -> putStrLn $ "Error: " ++ show e
     Right r -> do
-      forM_ (Github.searchResultResults r) $ \r -> do
-        putStrLn $ formatIssue r
+      forM_ (GitHub.searchResultResults r) $ \r -> do
+        putStrLn $ formatRepo r
         putStrLn ""
-      putStrLn $ "Count: " ++ show (Github.searchResultTotalCount r)
-        ++ " Haskell repos created since " ++ date
+      putStrLn $ "Count: " ++ show (GitHub.searchResultTotalCount r)
+        ++ " Haskell repos created since " ++ T.unpack date
 
 -- | return today (in UTC) formatted as YYYY-MM-DD
-today :: IO String
+today :: IO Text
 today = do
   now <- getCurrentTime
   let day = localDay $ utcToLocalTime utc now
       (y,m,d) = toGregorian day
-   in return $ printf "%d-%02d-%02d" y m d
+   in return $ T.pack $ printf "%d-%02d-%02d" y m d
 
-formatRepo :: Github.Repo -> String
+formatRepo :: GitHub.Repo -> String
 formatRepo r =
-  let fields = [ ("Name", show . Github.repoName)
-                 ,("URL",  show . Github.repoHtmlUrl)
-                 ,("Description", show . orEmpty . Github.repoDescription)
-                 ,("Created-At", formatMaybeDate . Github.repoCreatedAt)
-                 ,("Pushed-At", formatMaybeDate . Github.repoPushedAt)
-                 ,("Stars", show . Github.repoStargazersCount)
+  let fields = [ ("Name", show . GitHub.repoName)
+                 ,("URL",  show . GitHub.repoHtmlUrl)
+                 ,("Description", show . orEmpty . GitHub.repoDescription)
+                 ,("Created-At", formatMaybeDate . GitHub.repoCreatedAt)
+                 ,("Pushed-At", formatMaybeDate . GitHub.repoPushedAt)
+                 ,("Stars", show . GitHub.repoStargazersCount)
                ]
   in intercalate "\n" $ map fmt fields
     where fmt (s,f) = fill 12 (s ++ ":") ++ " " ++ f r
@@ -52,4 +54,5 @@ formatRepo r =
             where n' = max 0 (n - length s) 
 
 
+formatMaybeDate :: Maybe UTCTime -> String
 formatMaybeDate = maybe "???" show

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -152,16 +152,19 @@ executable github-show-user-2
 
 executable github-search-code
   import:         deps
+  ghc-options:    -Wall -threaded
   main-is:        SearchCode.hs
   hs-source-dirs: Search
 
 executable github-search-issues
   import:         deps
+  ghc-options:    -Wall -threaded
   main-is:        SearchIssues.hs
   hs-source-dirs: Search
 
 executable github-search-repos
   import:         deps
+  ghc-options:    -Wall -threaded
   main-is:        SearchRepos.hs
   hs-source-dirs: Search
   build-depends:  time

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -150,6 +150,22 @@ executable github-show-user-2
   main-is:        ShowUser2.hs
   hs-source-dirs: Users
 
+executable github-search-code
+  import:         deps
+  main-is:        SearchCode.hs
+  hs-source-dirs: Search
+
+executable github-search-issues
+  import:         deps
+  main-is:        SearchIssues.hs
+  hs-source-dirs: Search
+
+executable github-search-repos
+  import:         deps
+  main-is:        SearchRepos.hs
+  hs-source-dirs: Search
+  build-depends:  time
+
 -- executable github-team-membership-info-for
 --   import:         deps
 --   main-is:        TeamMembershipInfoFor.hs

--- a/spec/GitHub/SearchSpec.hs
+++ b/spec/GitHub/SearchSpec.hs
@@ -18,7 +18,7 @@ import GitHub (github)
 import GitHub.Data
        (Auth (..), Issue (..), IssueNumber (..), IssueState (..),
        SimpleUser (..), User, mkId)
-import GitHub.Endpoints.Search (SearchResult (..), searchIssuesR, searchUsersR)
+import GitHub.Endpoints.Search (SearchResult' (..), SearchResult, searchIssuesR, searchUsersR)
 
 fromRightS :: Show a => Either a b -> b
 fromRightS (Right b) = b
@@ -55,13 +55,13 @@ spec = do
 
     it "performs an issue search via the API" $ withAuth $ \auth -> do
       let query = "Decouple in:title repo:phadej/github created:<=2015-12-01"
-      issues <- searchResultResults . fromRightS <$> github auth searchIssuesR query
+      issues <- fmap (searchResultResults . fromRightS) <$> github auth $ searchIssuesR query 5
       length issues `shouldBe` 1
       issueId (V.head issues) `shouldBe` mkId (Proxy :: Proxy Issue) 119694665
 
   describe "searchUsers" $
     it "performs a user search via the API" $ withAuth $ \auth -> do
       let query = "oleg.grenrus@iki.fi created:<2020-01-01"
-      users <- searchResultResults . fromRightS <$> github auth searchUsersR query
+      users <- fmap (searchResultResults . fromRightS) <$> github auth $ searchUsersR query 5
       length users `shouldBe` 1
       simpleUserId (V.head users) `shouldBe` mkId (Proxy :: Proxy User) 51087

--- a/src/GitHub/Data/Repos.hs
+++ b/src/GitHub/Data/Repos.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DuplicateRecordFields #-}
 #define UNSAFE 1
 -----------------------------------------------------------------------------
 -- |
@@ -70,34 +69,34 @@ instance NFData Repo where rnf = genericRnf
 instance Binary Repo
 
 data CodeSearchRepo = CodeSearchRepo
-    { repoId              :: !(Id Repo)
-    , repoName            :: !(Name Repo)
-    , repoOwner           :: !SimpleOwner
-    , repoPrivate         :: !Bool
-    , repoHtmlUrl         :: !URL
-    , repoDescription     :: !(Maybe Text)
-    , repoFork            :: !(Maybe Bool)
-    , repoUrl             :: !URL
-    , repoGitUrl          :: !(Maybe URL)
-    , repoSshUrl          :: !(Maybe URL)
-    , repoCloneUrl        :: !(Maybe URL)
-    , repoHooksUrl        :: !URL
-    , repoSvnUrl          :: !(Maybe URL)
-    , repoHomepage        :: !(Maybe Text)
-    , repoLanguage        :: !(Maybe Language)
-    , repoSize            :: !(Maybe Int)
-    , repoDefaultBranch   :: !(Maybe Text)
-    , repoHasIssues       :: !(Maybe Bool)
-    , repoHasProjects     :: !(Maybe Bool)
-    , repoHasWiki         :: !(Maybe Bool)
-    , repoHasPages        :: !(Maybe Bool)
-    , repoHasDownloads    :: !(Maybe Bool)
-    , repoArchived        :: !Bool
-    , repoDisabled        :: !Bool
-    , repoPushedAt        :: !(Maybe UTCTime)   -- ^ this is Nothing for new repositories
-    , repoCreatedAt       :: !(Maybe UTCTime)
-    , repoUpdatedAt       :: !(Maybe UTCTime)
-    , repoPermissions     :: !(Maybe RepoPermissions) -- ^ Repository permissions as they relate to the authenticated user.
+    { codeSearchRepoId              :: !(Id Repo)
+    , codeSearchRepoName            :: !(Name Repo)
+    , codeSearchRepoOwner           :: !SimpleOwner
+    , codeSearchRepoPrivate         :: !Bool
+    , codeSearchRepoHtmlUrl         :: !URL
+    , codeSearchRepoDescription     :: !(Maybe Text)
+    , codeSearchRepoFork            :: !(Maybe Bool)
+    , codeSearchRepoUrl             :: !URL
+    , codeSearchRepoGitUrl          :: !(Maybe URL)
+    , codeSearchRepoSshUrl          :: !(Maybe URL)
+    , codeSearchRepoCloneUrl        :: !(Maybe URL)
+    , codeSearchRepoHooksUrl        :: !URL
+    , codeSearchRepoSvnUrl          :: !(Maybe URL)
+    , codeSearchRepoHomepage        :: !(Maybe Text)
+    , codeSearchRepoLanguage        :: !(Maybe Language)
+    , codeSearchRepoSize            :: !(Maybe Int)
+    , codeSearchRepoDefaultBranch   :: !(Maybe Text)
+    , codeSearchRepoHasIssues       :: !(Maybe Bool)
+    , codeSearchRepoHasProjects     :: !(Maybe Bool)
+    , codeSearchRepoHasWiki         :: !(Maybe Bool)
+    , codeSearchRepoHasPages        :: !(Maybe Bool)
+    , codeSearchRepoHasDownloads    :: !(Maybe Bool)
+    , codeSearchRepoArchived        :: !Bool
+    , codeSearchRepoDisabled        :: !Bool
+    , codeSearchRepoPushedAt        :: !(Maybe UTCTime)   -- ^ this is Nothing for new repositories
+    , codeSearchRepoCreatedAt       :: !(Maybe UTCTime)
+    , codeSearchRepoUpdatedAt       :: !(Maybe UTCTime)
+    , codeSearchRepoPermissions     :: !(Maybe RepoPermissions) -- ^ Repository permissions as they relate to the authenticated user.
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 

--- a/src/GitHub/Data/Repos.hs
+++ b/src/GitHub/Data/Repos.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 #define UNSAFE 1
 -----------------------------------------------------------------------------
 -- |
@@ -67,6 +68,41 @@ data Repo = Repo
 
 instance NFData Repo where rnf = genericRnf
 instance Binary Repo
+
+data CodeSearchRepo = CodeSearchRepo
+    { repoId              :: !(Id Repo)
+    , repoName            :: !(Name Repo)
+    , repoOwner           :: !SimpleOwner
+    , repoPrivate         :: !Bool
+    , repoHtmlUrl         :: !URL
+    , repoDescription     :: !(Maybe Text)
+    , repoFork            :: !(Maybe Bool)
+    , repoUrl             :: !URL
+    , repoGitUrl          :: !(Maybe URL)
+    , repoSshUrl          :: !(Maybe URL)
+    , repoCloneUrl        :: !(Maybe URL)
+    , repoHooksUrl        :: !URL
+    , repoSvnUrl          :: !(Maybe URL)
+    , repoHomepage        :: !(Maybe Text)
+    , repoLanguage        :: !(Maybe Language)
+    , repoSize            :: !(Maybe Int)
+    , repoDefaultBranch   :: !(Maybe Text)
+    , repoHasIssues       :: !(Maybe Bool)
+    , repoHasProjects     :: !(Maybe Bool)
+    , repoHasWiki         :: !(Maybe Bool)
+    , repoHasPages        :: !(Maybe Bool)
+    , repoHasDownloads    :: !(Maybe Bool)
+    , repoArchived        :: !Bool
+    , repoDisabled        :: !Bool
+    , repoPushedAt        :: !(Maybe UTCTime)   -- ^ this is Nothing for new repositories
+    , repoCreatedAt       :: !(Maybe UTCTime)
+    , repoUpdatedAt       :: !(Maybe UTCTime)
+    , repoPermissions     :: !(Maybe RepoPermissions) -- ^ Repository permissions as they relate to the authenticated user.
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CodeSearchRepo where rnf = genericRnf
+instance Binary CodeSearchRepo
 
 -- | Repository permissions, as they relate to the authenticated user.
 --
@@ -218,6 +254,36 @@ instance FromJSON Repo where
         <*> o .:? "size"
         <*> o .:? "default_branch"
         <*> o .: "open_issues_count"
+        <*> o .:? "has_issues"
+        <*> o .:? "has_projects"
+        <*> o .:? "has_wiki"
+        <*> o .:? "has_pages"
+        <*> o .:? "has_downloads"
+        <*> o .:? "archived" .!= False
+        <*> o .:? "disabled" .!= False
+        <*> o .:? "pushed_at"
+        <*> o .:? "created_at"
+        <*> o .:? "updated_at"
+        <*> o .:? "permissions"
+
+instance FromJSON CodeSearchRepo where
+    parseJSON = withObject "Repo" $ \o -> CodeSearchRepo <$> o .: "id"
+        <*> o .: "name"
+        <*> o .: "owner"
+        <*> o .: "private"
+        <*> o .: "html_url"
+        <*> o .:? "description"
+        <*> o .: "fork"
+        <*> o .: "url"
+        <*> o .:? "git_url"
+        <*> o .:? "ssh_url"
+        <*> o .:? "clone_url"
+        <*> o .: "hooks_url"
+        <*> o .:? "svn_url"
+        <*> o .:? "homepage"
+        <*> o .:? "language"
+        <*> o .:? "size"
+        <*> o .:? "default_branch"
         <*> o .:? "has_issues"
         <*> o .:? "has_projects"
         <*> o .:? "has_wiki"

--- a/src/GitHub/Data/Search.hs
+++ b/src/GitHub/Data/Search.hs
@@ -12,19 +12,27 @@ import Prelude ()
 
 import qualified Data.Vector as V
 
-data SearchResult entity = SearchResult
+data SearchResult' entities = SearchResult
     { searchResultTotalCount :: !Int
-    , searchResultResults    :: !(Vector entity)
+    , searchResultResults    :: !entities
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData entity => NFData (SearchResult entity) where rnf = genericRnf
-instance Binary entity => Binary (SearchResult entity)
+type SearchResult entity = SearchResult' (V.Vector entity)
 
-instance FromJSON entity => FromJSON (SearchResult entity) where
+instance NFData entities => NFData (SearchResult' entities) where rnf = genericRnf
+instance Binary entities => Binary (SearchResult' entities)
+
+instance (Monoid entities, FromJSON entities) => FromJSON (SearchResult' entities) where
     parseJSON = withObject "SearchResult" $ \o -> SearchResult
         <$> o .: "total_count"
-        <*> o .:? "items" .!= V.empty
+        <*> o .:? "items" .!= mempty
+
+instance Semigroup res => Semigroup (SearchResult' res) where
+    (SearchResult count res) <> (SearchResult count' res') = SearchResult (max count count') (res <> res')
+
+instance Foldable SearchResult' where
+    foldMap f (SearchResult count results) = f results
 
 data Code = Code
     { codeName    :: !Text

--- a/src/GitHub/Data/Search.hs
+++ b/src/GitHub/Data/Search.hs
@@ -5,7 +5,7 @@
 --
 module GitHub.Data.Search where
 
-import GitHub.Data.Repos       (Repo)
+import GitHub.Data.Repos       (CodeSearchRepo)
 import GitHub.Data.URL         (URL)
 import GitHub.Internal.Prelude
 import Prelude ()
@@ -41,7 +41,7 @@ data Code = Code
     , codeUrl     :: !URL
     , codeGitUrl  :: !URL
     , codeHtmlUrl :: !URL
-    , codeRepo    :: !Repo
+    , codeRepo    :: !CodeSearchRepo
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 

--- a/src/GitHub/Endpoints/Search.hs
+++ b/src/GitHub/Endpoints/Search.hs
@@ -21,24 +21,24 @@ import qualified Data.Text.Encoding as TE
 
 -- | Search repositories.
 -- See <https://developer.github.com/v3/search/#search-repositories>
-searchReposR :: Text -> Request k (SearchResult Repo)
+searchReposR :: Text -> FetchCount -> Request k (SearchResult Repo)
 searchReposR searchString =
-    query ["search", "repositories"] [("q", Just $ TE.encodeUtf8 searchString)]
+    PagedQuery ["search", "repositories"] [("q", Just $ TE.encodeUtf8 searchString)]
 
 -- | Search code.
 -- See <https://developer.github.com/v3/search/#search-code>
-searchCodeR :: Text -> Request k (SearchResult Code)
+searchCodeR :: Text -> FetchCount -> Request k (SearchResult Code)
 searchCodeR searchString =
-    query ["search", "code"] [("q", Just $ TE.encodeUtf8 searchString)]
+    PagedQuery ["search", "code"] [("q", Just $ TE.encodeUtf8 searchString)]
 
 -- | Search issues.
 -- See <https://developer.github.com/v3/search/#search-issues>
-searchIssuesR :: Text -> Request k (SearchResult Issue)
+searchIssuesR :: Text -> FetchCount -> Request k (SearchResult Issue)
 searchIssuesR searchString =
-    query ["search", "issues"] [("q", Just $ TE.encodeUtf8 searchString)]
+    PagedQuery ["search", "issues"] [("q", Just $ TE.encodeUtf8 searchString)]
 
 -- | Search users.
 -- See <https://developer.github.com/v3/search/#search-code>
-searchUsersR :: Text -> Request k (SearchResult SimpleUser)
+searchUsersR :: Text -> FetchCount -> Request k (SearchResult SimpleUser)
 searchUsersR searchString =
-  query ["search", "users"] [("q", Just $ TE.encodeUtf8 searchString)]
+    PagedQuery ["search", "users"] [("q", Just $ TE.encodeUtf8 searchString)]


### PR DESCRIPTION
Previously, searches only returned the first thirty results, and there was no way to access page two.

Note that this is a breaking API change.