### PR TITLE
Drop unused dependency vector-instances

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220504
+# version: 0.15.20220525
 #
-# REGENDATA ("0.15.20220504",["--config=cabal.haskell-ci","github","cabal.project"])
+# REGENDATA ("0.15.20220525",["--config=cabal.haskell-ci","github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.0.20220501
+            compilerKind: ghc
+            compilerVersion: 9.4.0.20220501
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.2.2
             compilerKind: ghc
             compilerVersion: 9.2.2
@@ -90,8 +95,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            if $HEADHACKAGE; then "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml; fi
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           else
@@ -99,7 +105,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -132,7 +138,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -161,6 +167,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -191,7 +208,7 @@ jobs:
         run: |
           touch cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
-          if [ $((HCNUMVER >= 71000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/samples" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 71000 && HCNUMVER < 90400)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/samples" >> cabal.project ; fi
           cat cabal.project
       - name: sdist
         run: |
@@ -211,16 +228,19 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_github}" >> cabal.project
-          if [ $((HCNUMVER >= 71000)) -ne 0 ] ; then echo "packages: ${PKGDIR_github_samples}" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 71000 && HCNUMVER < 90400)) -ne 0 ] ; then echo "packages: ${PKGDIR_github_samples}" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90400)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           constraints:  github +openssl
           constraints:  github-samples +openssl
           optimization: False
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(github|github-samples)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -251,8 +271,8 @@ jobs:
         run: |
           cd ${PKGDIR_github} || false
           ${CABAL} -vnormal check
-          if [ $((HCNUMVER >= 71000)) -ne 0 ] ; then cd ${PKGDIR_github_samples} || false ; fi
-          if [ $((HCNUMVER >= 71000)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER >= 71000 && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_github_samples} || false ; fi
+          if [ $((HCNUMVER >= 71000 && HCNUMVER < 90400)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/github.cabal
+++ b/github.cabal
@@ -40,6 +40,7 @@ tested-with:
    || ==8.10.7
    || ==9.0.2
    || ==9.2.2
+   || ==9.4.1
 
 extra-source-files:
   README.md
@@ -165,7 +166,7 @@ library
 
   -- Packages bundles with GHC, mtl and text are also here
   build-depends:
-      base          >=4.7      && <4.17
+      base          >=4.7      && <5
     , binary        >=0.7.1.0  && <0.11
     , bytestring    >=0.10.4.0 && <0.12
     , containers    >=0.5.5.1  && <0.7
@@ -194,7 +195,6 @@ library
     , transformers-compat   >=0.6.5      && <0.8
     , unordered-containers  >=0.2.10.0   && <0.3
     , vector                >=0.12.0.1   && <0.13
-    , vector-instances      >=3.4        && <3.5
 
   if flag(openssl)
     build-depends:

--- a/github.cabal
+++ b/github.cabal
@@ -72,6 +72,7 @@ library
     DeriveGeneric
     OverloadedStrings
     ScopedTypeVariables
+    TypeOperators
 
   other-extensions:
     CPP

--- a/src/GitHub/Internal/Prelude.hs
+++ b/src/GitHub/Internal/Prelude.hs
@@ -57,6 +57,5 @@ import Data.Text                (Text, pack, unpack)
 import Data.Time.Compat         (UTCTime)
 import Data.Time.ISO8601        (formatISO8601)
 import Data.Vector              (Vector)
-import Data.Vector.Instances ()
 import GHC.Generics             (Generic)
 import Prelude.Compat


### PR DESCRIPTION
Also tested GHC 9.4 compatibility and published revision: https://hackage.haskell.org/package/github-0.28/revisions/

Extra settings for building with GHC 9.4 alpha2:
```
allow-newer: HsOpenSSL:template-haskell
allow-newer: HsOpenSSL:time

allow-newer: hsc2hs:*

allow-newer: async:base

allow-newer: time-compat:base

allow-newer: tagged:template-haskell

allow-newer: http-api-data:base

allow-newer: hashable:base
allow-newer: hashable:ghc-bignum

allow-newer: deepseq-generics:base
allow-newer: deepseq-generics:ghc-prim

allow-newer: cryptohash-sha1:base

allow-newer: binary-instances:base
allow-newer: vector-binary-instances:base

allow-newer: integer-logarithms:base
allow-newer: integer-logarithms:ghc-prim
allow-newer: integer-logarithms:ghc-bignum

allow-newer: scientific:base
allow-newer: scientific:template-haskell

allow-newer: binary-orphans:base

allow-newer: aeson:base
allow-newer: aeson:ghc-prim
allow-newer: aeson:template-haskell
allow-newer: aeson:attoparsec

allow-newer: attoparsec:ghc-prim

allow-newer: uuid-types:template-haskell

allow-newer: indexed-traversable:base
allow-newer: indexed-traversable-instances:base

allow-newer: these:base
allow-newer: assoc:base
allow-newer: semialign:base
allow-newer: data-fix:base
allow-newer: splitmix:base
allow-newer: OneTuple:base

allow-newer: text-short:base
allow-newer: text-short:ghc-prim
allow-newer: text-short:template-haskell

allow-newer: bifunctors:template-haskell
allow-newer: th-abstraction:template-haskell
```
