### PR TITLE
v0.28.0.1 Revision 1: Allow base-compat-0.13, bump CI to GHC 9.6.1

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -1,6 +1,7 @@
 cabal-version:      >=1.10
 name:               github
 version:            0.28.0.1
+x-revision:         1
 synopsis:           Access to the GitHub API, v3.
 category:           Network
 description:
@@ -181,7 +182,7 @@ library
   -- other packages
   build-depends:
       aeson                 >=1.4.0.0    && <1.6 || >=2.0.1.0 && <2.2
-    , base-compat           >=0.11.1     && <0.13
+    , base-compat           >=0.11.1     && <0.14
     , base16-bytestring     >=0.1.1.6    && <1.1
     , binary-instances      >=1          && <1.1
     , cryptohash-sha1       >=0.11.100.1 && <0.12


### PR DESCRIPTION
Published as revision 1: https://hackage.haskell.org/package/github-0.28.0.1/revisions/