### PR TITLE
Use FetchCountable instead of Foldable

### DIFF
--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -199,11 +199,6 @@ executeRequest auth req = withOpenSSL $ do
     manager <- newManager tlsManagerSettings
     executeRequestWithMgr manager auth req
 
-lessFetchCount :: Int -> FetchCount -> Bool
-lessFetchCount _ FetchAll         = True
-lessFetchCount i (FetchAtLeast j) = i < fromIntegral j
-
-
 -- | Like 'executeRequest' but with provided 'Manager'.
 executeRequestWithMgr
     :: (AuthMethod am, ParseResponse mt a)
@@ -238,7 +233,7 @@ executeRequestWithMgrAndRes mgr auth req = runExceptT $ do
     performHttpReq httpReq (PagedQuery _ _ l) =
         unTagged (performPagedRequest httpLbs' predicate httpReq :: Tagged mt (ExceptT Error IO (HTTP.Response b)))
       where
-        predicate v = lessFetchCount (length v) l
+        predicate v = lessFetchCount v l
 
     performHttpReq httpReq (Command _ _ _) = do
         res <- httpLbs' httpReq


### PR DESCRIPTION
Here's a way to support apis like this:

https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-repositories-accessible-to-the-user-access-token

I just realised it should also be possible to do this with a special `Foldable` type like this

```
data WithTotalCount (key :: Symbol) a = WithTotalCount { totalCount :: Int, values :: [a] }
```

Up to you which you prefer.
If you don't want this patch then that's fine and I'll make such a foldable instead.
