### PR TITLE
fix: add missing `name` field to `WorkflowJobs` `Job` type

### DIFF
--- a/src/GitHub/Data/Actions/WorkflowJobs.hs
+++ b/src/GitHub/Data/Actions/WorkflowJobs.hs
@@ -47,6 +47,7 @@ data Job = Job
     , jobConclusion      :: !Text
     , jobStartedAt       :: !UTCTime
     , jobCompletedAt     :: !UTCTime
+    , jobName            :: !(Name Job)
     , jobSteps           :: !(Vector JobStep)
     , jobRunCheckUrl     :: !URL
     , jobLabels          :: !(Vector Text)
@@ -84,6 +85,7 @@ instance FromJSON Job where
         <*> o .: "conclusion"
         <*> o .: "started_at"
         <*> o .: "completed_at"
+        <*> o .: "name"
         <*> o .: "steps"
         <*> o .: "check_run_url"
         <*> o .: "labels"


### PR DESCRIPTION
The `Job` type was missing a field from the schema in https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#list-jobs-for-a-workflow-run