### PR TITLE
Revert "Revert "Support pagination""

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -264,6 +264,7 @@ test-suite github-test
     , file-embed
     , github
     , hspec                 >=2.6.1 && <2.12
+    , http-client
     , tagged
     , text
     , unordered-containers

--- a/spec/GitHub/IssuesSpec.hs
+++ b/spec/GitHub/IssuesSpec.hs
@@ -6,12 +6,13 @@ import qualified GitHub
 import Prelude ()
 import Prelude.Compat
 
-import Data.Either.Compat (isRight)
-import Data.Foldable      (for_)
-import Data.String        (fromString)
-import System.Environment (lookupEnv)
-import Test.Hspec
-       (Spec, describe, expectationFailure, it, pendingWith, shouldSatisfy)
+import Data.Either.Compat  (isRight)
+import Data.Foldable       (for_)
+import Data.String         (fromString)
+import Network.HTTP.Client (newManager, responseBody)
+import System.Environment  (lookupEnv)
+import Test.Hspec          (Spec, describe, expectationFailure, it, pendingWith, shouldSatisfy)
+
 
 fromRightS :: Show a => Either a b -> b
 fromRightS (Right b) = b
@@ -38,6 +39,25 @@ spec = do
                   cms <- GitHub.executeRequest auth $
                     GitHub.commentsR owner repo (GitHub.issueNumber i) 1
                   cms `shouldSatisfy` isRight
+
+    describe "issuesForRepoR paged" $ do
+        it "works" $ withAuth $ \auth -> for_ repos $ \(owner, repo) -> do
+            mgr <- newManager GitHub.tlsManagerSettings
+            ret <- GitHub.executeRequestWithMgrAndRes mgr auth $
+                GitHub.issuesForRepoR owner repo mempty (GitHub.FetchPage (GitHub.PageParams (Just 2) (Just 1)))
+
+            case ret of
+              Left e ->
+                expectationFailure . show $ e
+              Right res -> do
+                let issues = responseBody res
+                length issues `shouldSatisfy` (<= 2)
+
+                for_ issues $ \i -> do
+                  cms <- GitHub.executeRequest auth $
+                    GitHub.commentsR owner repo (GitHub.issueNumber i) 1
+                  cms `shouldSatisfy` isRight
+
     describe "issueR" $ do
         it "fetches issue #428" $ withAuth $ \auth -> do
             resIss <- GitHub.executeRequest auth $

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -14,6 +14,8 @@ module GitHub.Data.Request (
     CommandMethod(..),
     toMethod,
     FetchCount(..),
+    PageParams(..),
+    PageLinks(..),
     MediaType (..),
     Paths,
     IsPathPart(..),
@@ -29,6 +31,7 @@ import GitHub.Internal.Prelude
 import qualified Data.ByteString.Lazy      as LBS
 import qualified Data.Text                 as T
 import qualified Network.HTTP.Types.Method as Method
+import Network.URI (URI)
 
 ------------------------------------------------------------------------------
 -- Path parts
@@ -74,7 +77,10 @@ toMethod Delete = Method.methodDelete
 
 -- | 'PagedQuery' returns just some results, using this data we can specify how
 -- many pages we want to fetch.
-data FetchCount = FetchAtLeast !Word | FetchAll
+data FetchCount =
+    FetchAtLeast !Word
+    | FetchAll
+    | FetchPage PageParams
     deriving (Eq, Ord, Read, Show, Generic, Typeable)
 
 
@@ -95,6 +101,37 @@ instance Num FetchCount where
 instance Hashable FetchCount
 instance Binary FetchCount
 instance NFData FetchCount where rnf = genericRnf
+
+-------------------------------------------------------------------------------
+-- PageParams
+-------------------------------------------------------------------------------
+
+-- | Params for specifying the precise page and items per page.
+data PageParams = PageParams {
+    pageParamsPerPage :: Maybe Int
+    , pageParamsPage :: Maybe Int
+    }
+    deriving (Eq, Ord, Read, Show, Generic, Typeable)
+
+instance Hashable PageParams
+instance Binary PageParams
+instance NFData PageParams where rnf = genericRnf
+
+-------------------------------------------------------------------------------
+-- PageLinks
+-------------------------------------------------------------------------------
+
+-- | 'PagedQuery' returns just some results, using this data we can specify how
+-- many pages we want to fetch.
+data PageLinks = PageLinks {
+    pageLinksPrev :: Maybe URI
+    , pageLinksNext :: Maybe URI
+    , pageLinksLast :: Maybe URI
+    , pageLinksFirst :: Maybe URI
+    }
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+instance NFData PageLinks where rnf = genericRnf
 
 -------------------------------------------------------------------------------
 -- MediaType

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -500,8 +500,8 @@ makeHttpRequest auth r = case r of
     extraQueryItems :: [(BS.ByteString, Maybe BS.ByteString)]
     extraQueryItems = case r of
       PagedQuery _ _ (FetchPage pp) -> catMaybes [
-          (\page -> ("page", Just (BS.toStrict $ toLazyByteString $ intDec page))) <$> pageParamsPage pp
-          , (\perPage -> ("per_page", Just (BS.toStrict $ toLazyByteString $ intDec perPage))) <$> pageParamsPerPage pp
+          (\page -> ("page", Just (LBS.toStrict $ toLazyByteString $ intDec page))) <$> pageParamsPage pp
+          , (\perPage -> ("per_page", Just (LBS.toStrict $ toLazyByteString $ intDec perPage))) <$> pageParamsPerPage pp
           ]
       _ -> []
 


### PR DESCRIPTION
Reverts haskell-github/github#521

CI reports build failures with GHC 9.0 and below:
``` 

[93 of 94] Compiling GitHub.Request   ( src/GitHub/Request.hs, /__w/github/github/dist-newstyle/build/x86_64-linux/ghc-8.2.2/github-0.29.1/noopt/build/GitHub/Request.o )

src/GitHub/Request.hs:503:36: error:
    Not in scope: ‘BS.toStrict’
    Perhaps you meant ‘LBS.toStrict’ (imported from Data.ByteString.Lazy)
    Module ‘Data.ByteString’ does not export ‘toStrict’.
    |
503 |           (\page -> ("page", Just (BS.toStrict $ toLazyByteString $ intDec page))) <$> pageParamsPage pp
    |                                    ^^^^^^^^^^^

src/GitHub/Request.hs:504:45: error:
    Not in scope: ‘BS.toStrict’
    Perhaps you meant ‘LBS.toStrict’ (imported from Data.ByteString.Lazy)
    Module ‘Data.ByteString’ does not export ‘toStrict’.
    |
504 |           , (\perPage -> ("per_page", Just (BS.toStrict $ toLazyByteString $ intDec perPage))) <$> pageParamsPerPage pp
    |                                             ^^^^^^^^^^^
```
Following the suggestions fixes the problem (https://github.com/haskell/bytestring/pull/281).