### PR TITLE
v0.30.0.1: drop deepseq-generics

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -246,10 +246,6 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
           if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250506",["--config=cabal.haskell-ci","github","cabal.project"])
+# REGENDATA ("0.19.20250821",["--config=cabal.haskell-ci","github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250819
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -105,11 +110,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -131,7 +151,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -159,6 +179,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -211,9 +243,17 @@ jobs:
           echo "packages: ${PKGDIR_github}" >> cabal.project
           if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "packages: ${PKGDIR_github_samples}" >> cabal.project ; fi
           echo "package github" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
           if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           constraints:  github +openssl
           constraints:  github-samples +openssl
@@ -221,6 +261,9 @@ jobs:
           constraints:  operational -buildExamples
           optimization: False
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(github|github-samples)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Changes for 0.30.0.1
+
+_2025-08-27, Andreas Abel_
+
+- Drop dependencies `deepseq-generics` and `transformers-compat`.
+- Remove obsolete `deriving Typeable`.
+
+Tested with GHC 8.2 - 9.14 alpha1.
+
 ## Changes for 0.30
 
 _2025-05-09, Andreas Abel, Peace edition_

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -3,6 +3,11 @@ haddock: >=8.6
   -- See PR #355: haddocks for GADT constructor arguments only supported from GHC 8.6
 jobs-selection: any
 
+-- Package github-samples uses "include" for dependencies,
+-- so they are a superset.
+-- Dissecting this is a waste of time, so I turn -Werror=unused-packages off
+error-unused-packages: False
+
 -- Some dependencies do not allow mtl-2.3 yet, so this doesn't pass yet:
 -- constraint-set mtl-2.3
 --   ghc: >= 8.6

--- a/github.cabal
+++ b/github.cabal
@@ -211,7 +211,6 @@ library
     , iso8601-time          >=0.1.5      && <0.2
     , network-uri           >=2.6.1.0    && <2.7
     , tagged                >=0.8.5      && <0.9
-    , transformers-compat   >=0.6.5      && <0.8
     , unordered-containers  >=0.2.10.0   && <0.3
     , vector                >=0.12.0.1   && <0.14
 

--- a/github.cabal
+++ b/github.cabal
@@ -184,17 +184,18 @@ library
   autogen-modules: Paths_github
 
   -- Packages bundles with GHC, mtl and text are also here
+  -- Lower bounds at least those of https://www.stackage.org/lts-10.0 (GHC 8.2.2)
   build-depends:
       base          >=4.10     && <5
-    , binary        >=0.7.1.0  && <0.11
-    , bytestring    >=0.10.4.0 && <0.13
-    , containers    >=0.5.5.1  && <1
-    , deepseq       >=1.3.0.2  && <1.6
+    , binary        >=0.8.5.1  && <0.11
+    , bytestring    >=0.10.8.2 && <0.13
+    , containers    >=0.5.10.2 && <1
+    , deepseq       >=1.4.3.0  && <1.6
     , exceptions    >=0.10.2   && <0.11
-    , mtl           >=2.1.3.1  && <2.2 || >=2.2.1 && <2.4
-    , text          >=1.2.0.6  && <2.2
+    , mtl           >=2.2.1    && <2.4
+    , text          >=1.2.2.2  && <2.2
     , time          >=1.8.0.2  && <2
-    , transformers  >=0.3.0.0  && <0.7
+    , transformers  >=0.5.2.0  && <0.7
 
   -- other packages
   build-depends:

--- a/github.cabal
+++ b/github.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               github
-version:            0.30
+version:            0.30.0.1
 synopsis:           Access to the GitHub API, v3.
 category:           Network
 description:
@@ -30,6 +30,7 @@ copyright:
   Copyright 2012-2013 Mike Burns, Copyright 2013-2015 John Wiegley, Copyright 2016-2021 Oleg Grenrus
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4

--- a/github.cabal
+++ b/github.cabal
@@ -203,7 +203,6 @@ library
     , base16-bytestring     >=0.1.1.6    && <1.1
     , binary-instances      >=1          && <1.1
     , cryptohash-sha1       >=0.11.100.1 && <0.12
-    , deepseq-generics      >=0.2.0.0    && <0.3
     , hashable              >=1.2.7.0    && <2
     , http-client           >=0.5.12     && <0.8
     , http-link-header      >=1.0.3.1    && <1.3

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -29,7 +29,6 @@ library
   build-depends:
     , base                   >=4.11 && <5
         -- require base-4.11 because then (<>) is in Prelude
-    , base-compat-batteries
     , github
     , text
 

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -10,6 +10,7 @@ description:   Various samples of github package
 build-type:    Simple
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4

--- a/spec/GitHub/ReposSpec.hs
+++ b/spec/GitHub/ReposSpec.hs
@@ -1,4 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+
+#if __GLASGOW_HASKELL__ >= 900
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+#endif
+
 module GitHub.ReposSpec where
 
 import GitHub

--- a/src/GitHub/Auth.hs
+++ b/src/GitHub/Auth.hs
@@ -25,7 +25,7 @@ data Auth
     | EnterpriseOAuth Text Token             -- ^ Custom endpoint and OAuth token
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Auth where rnf = genericRnf
+instance NFData Auth
 instance Binary Auth
 instance Hashable Auth
 

--- a/src/GitHub/Auth.hs
+++ b/src/GitHub/Auth.hs
@@ -23,7 +23,7 @@ data Auth
     | OAuth Token                            -- ^ OAuth token
     | JWT JWTToken                           -- ^ JWT Token
     | EnterpriseOAuth Text Token             -- ^ Custom endpoint and OAuth token
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Auth
 instance Binary Auth

--- a/src/GitHub/Data/Actions/Artifacts.hs
+++ b/src/GitHub/Data/Actions/Artifacts.hs
@@ -27,7 +27,7 @@ data ArtifactWorkflowRun  = ArtifactWorkflowRun
     , artifactWorkflowRunHeadBranch       :: !Text
     , artifactWorkflowRunHeadSha          :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data Artifact = Artifact
     { artifactArchiveDownloadUrl :: !URL
@@ -42,7 +42,7 @@ data Artifact = Artifact
     , artifactUrl                :: !URL
     , artifactWorkflowRun        :: !ArtifactWorkflowRun
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 -------------------------------------------------------------------------------
 -- JSON instances

--- a/src/GitHub/Data/Actions/Cache.hs
+++ b/src/GitHub/Data/Actions/Cache.hs
@@ -27,20 +27,20 @@ data Cache = Cache
     , cacheCreatedAt      :: !UTCTime
     , cacheSizeInBytes    :: !Int
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data RepositoryCacheUsage = RepositoryCacheUsage
     { repositoryCacheUsageFullName                :: !Text
     , repositoryCacheUsageActiveCachesSizeInBytes :: !Int
     , repositoryCacheUsageActiveCachesCount       :: !Int
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data OrganizationCacheUsage = OrganizationCacheUsage
     { organizationCacheUsageTotalActiveCachesSizeInBytes :: !Int
     , organizationCacheUsageTotalActiveCachesCount       :: !Int
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 -------------------------------------------------------------------------------
 -- JSON instances

--- a/src/GitHub/Data/Actions/Common.hs
+++ b/src/GitHub/Data/Actions/Common.hs
@@ -20,7 +20,7 @@ data WithTotalCount a = WithTotalCount
     , withTotalCountTotalCount :: !Int
         -- ^ The total size of the answer.
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 -- | Joining two pages of a paginated response.
 --   The 'withTotalCountTotalCount' is assumed to be the same in both pages,

--- a/src/GitHub/Data/Actions/Secrets.hs
+++ b/src/GitHub/Data/Actions/Secrets.hs
@@ -33,13 +33,13 @@ data OrganizationSecret = OrganizationSecret
     , organizationSecretUpdatedAt :: !UTCTime
     , organizationSecretVisibility :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data PublicKey = PublicKey
     { publicKeyId :: !Text
     , publicKeyKey :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data SetSecret = SetSecret
     { setSecretPublicKeyId :: !Text
@@ -47,35 +47,35 @@ data SetSecret = SetSecret
     , setSecretVisibility :: !Text
     , setSecretSelectedRepositoryIds :: !(Maybe [Id Repo])
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data SetRepoSecret = SetRepoSecret
     { setRepoSecretPublicKeyId :: !Text
     , setRepoSecretEncryptedValue :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data SelectedRepo = SelectedRepo
     { selectedRepoRepoId :: !(Id Repo)
     , selectedRepoRepoName :: !(Name Repo)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data SetSelectedRepositories = SetSelectedRepositories
     { setSelectedRepositoriesRepositoryIds :: ![Id Repo]
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data RepoSecret = RepoSecret
     { repoSecretName :: !(Name RepoSecret)
     , repoSecretCreatedAt :: !UTCTime
     , repoSecretUpdatedAt :: !UTCTime
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 -- TODO move somewhere else?
 data Environment = Environment
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 -------------------------------------------------------------------------------
 -- JSON instances

--- a/src/GitHub/Data/Actions/WorkflowJobs.hs
+++ b/src/GitHub/Data/Actions/WorkflowJobs.hs
@@ -10,7 +10,7 @@ module GitHub.Data.Actions.WorkflowJobs (
 import Prelude ()
 import GitHub.Internal.Prelude
        (Applicative ((<*>)), Data, Eq, FromJSON (parseJSON), Generic, Integer,
-       Ord, Show, Text, Typeable, UTCTime, Vector, withObject, ($), (.:),
+       Ord, Show, Text, UTCTime, Vector, withObject, ($), (.:),
        (<$>))
 
 import GitHub.Data.Id                   (Id)
@@ -32,7 +32,7 @@ data JobStep = JobStep
     , jobStepStartedAt   :: !UTCTime
     , jobStepCompletedAt :: !UTCTime
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data Job = Job
     { jobId              :: !(Id Job)
@@ -56,7 +56,7 @@ data Job = Job
     , jobRunnerGroupId   :: !Integer
     , jobRunnerGroupName :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 -------------------------------------------------------------------------------
 -- JSON instances

--- a/src/GitHub/Data/Actions/WorkflowRuns.hs
+++ b/src/GitHub/Data/Actions/WorkflowRuns.hs
@@ -41,10 +41,10 @@ data WorkflowRun  = WorkflowRun
     , workflowRunAttempt :: !Integer
     , workflowRunStartedAt :: !UTCTime
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data RunAttempt = RunAttempt
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data ReviewHistory  = ReviewHistory
     { reviewHistoryState :: !Text
@@ -52,7 +52,7 @@ data ReviewHistory  = ReviewHistory
     , reviewHistoryUser :: !SimpleUser
 
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 -------------------------------------------------------------------------------
 -- JSON instances

--- a/src/GitHub/Data/Actions/Workflows.hs
+++ b/src/GitHub/Data/Actions/Workflows.hs
@@ -25,7 +25,7 @@ data Workflow = Workflow
     , workflowHtmlUrl    :: !URL
     , workflowBadgeUrl   :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 data CreateWorkflowDispatchEvent a = CreateWorkflowDispatchEvent
     { createWorkflowDispatchEventRef    :: !Text

--- a/src/GitHub/Data/Actions/Workflows.hs
+++ b/src/GitHub/Data/Actions/Workflows.hs
@@ -33,7 +33,7 @@ data CreateWorkflowDispatchEvent a = CreateWorkflowDispatchEvent
     }
   deriving (Show, Generic)
 
-instance (NFData a) => NFData (CreateWorkflowDispatchEvent a) where rnf = genericRnf
+instance (NFData a) => NFData (CreateWorkflowDispatchEvent a)
 instance (Binary a) => Binary (CreateWorkflowDispatchEvent a)
 
 -------------------------------------------------------------------------------

--- a/src/GitHub/Data/Activities.hs
+++ b/src/GitHub/Data/Activities.hs
@@ -15,7 +15,7 @@ data RepoStarred = RepoStarred
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RepoStarred where rnf = genericRnf
+instance NFData RepoStarred
 instance Binary RepoStarred
 
 -- JSON Instances
@@ -35,7 +35,7 @@ data Subject = Subject
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Subject where rnf = genericRnf
+instance NFData Subject
 instance Binary Subject
 
 instance FromJSON Subject where
@@ -63,7 +63,7 @@ data NotificationReason
     | TeamMentionReason
   deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
 
-instance NFData NotificationReason where rnf = genericRnf
+instance NFData NotificationReason
 instance Binary NotificationReason
 
 instance FromJSON NotificationReason where
@@ -99,7 +99,7 @@ data Notification = Notification
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Notification where rnf = genericRnf
+instance NFData Notification
 instance Binary Notification
 
 instance FromJSON Notification where

--- a/src/GitHub/Data/Activities.hs
+++ b/src/GitHub/Data/Activities.hs
@@ -13,7 +13,7 @@ data RepoStarred = RepoStarred
     { repoStarredStarredAt :: !UTCTime
     , repoStarredRepo      :: !Repo
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RepoStarred
 instance Binary RepoStarred
@@ -33,7 +33,7 @@ data Subject = Subject
     -- TODO: Make an ADT for this.
     , subjectType :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Subject
 instance Binary Subject
@@ -61,7 +61,7 @@ data NotificationReason
     | StateChangeReason
     | SubscribedReason
     | TeamMentionReason
-  deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Enum, Bounded, Eq, Ord, Generic)
 
 instance NFData NotificationReason
 instance Binary NotificationReason
@@ -97,7 +97,7 @@ data Notification = Notification
     , notificationLastReadAt :: !(Maybe UTCTime)
     , notificationUrl :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Notification
 instance Binary Notification

--- a/src/GitHub/Data/Comments.hs
+++ b/src/GitHub/Data/Comments.hs
@@ -19,7 +19,7 @@ data Comment = Comment
     , commentUser      :: !SimpleUser
     , commentId        :: !(Id Comment)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Comment
 instance Binary Comment
@@ -41,7 +41,7 @@ instance FromJSON Comment where
 data NewComment = NewComment
     { newCommentBody :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewComment
 instance Binary NewComment
@@ -52,7 +52,7 @@ instance ToJSON NewComment where
 data EditComment = EditComment
     { editCommentBody :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData EditComment
 instance Binary EditComment
@@ -66,7 +66,7 @@ data NewPullComment = NewPullComment
     , newPullCommentPosition :: !Int
     , newPullCommentBody     :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewPullComment
 instance Binary NewPullComment
@@ -82,7 +82,7 @@ instance ToJSON NewPullComment where
 data PullCommentReply = PullCommentReply
     { pullCommentReplyBody     :: Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData PullCommentReply
 

--- a/src/GitHub/Data/Comments.hs
+++ b/src/GitHub/Data/Comments.hs
@@ -21,7 +21,7 @@ data Comment = Comment
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Comment where rnf = genericRnf
+instance NFData Comment
 instance Binary Comment
 
 instance FromJSON Comment where
@@ -43,7 +43,7 @@ data NewComment = NewComment
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewComment where rnf = genericRnf
+instance NFData NewComment
 instance Binary NewComment
 
 instance ToJSON NewComment where
@@ -54,7 +54,7 @@ data EditComment = EditComment
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData EditComment where rnf = genericRnf
+instance NFData EditComment
 instance Binary EditComment
 
 instance ToJSON EditComment where
@@ -68,7 +68,7 @@ data NewPullComment = NewPullComment
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewPullComment where rnf = genericRnf
+instance NFData NewPullComment
 instance Binary NewPullComment
 
 instance ToJSON NewPullComment where
@@ -84,7 +84,7 @@ data PullCommentReply = PullCommentReply
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData PullCommentReply where rnf = genericRnf
+instance NFData PullCommentReply
 
 instance ToJSON PullCommentReply where
     toJSON (PullCommentReply b) =

--- a/src/GitHub/Data/Content.hs
+++ b/src/GitHub/Data/Content.hs
@@ -18,7 +18,7 @@ import Data.Aeson (Key)
 data Content
   = ContentFile !ContentFileData
   | ContentDirectory !(Vector ContentItem)
- deriving (Show, Data, Typeable, Eq, Ord, Generic)
+ deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Content
 instance Binary Content
@@ -28,7 +28,7 @@ data ContentFileData = ContentFileData {
   ,contentFileEncoding :: !Text
   ,contentFileSize     :: !Int
   ,contentFileContent  :: !Text
-} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+} deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData ContentFileData
 instance Binary ContentFileData
@@ -37,13 +37,13 @@ instance Binary ContentFileData
 data ContentItem = ContentItem {
    contentItemType :: !ContentItemType
   ,contentItemInfo :: !ContentInfo
-} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+} deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData ContentItem
 instance Binary ContentItem
 
 data ContentItemType = ItemFile | ItemDir
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData ContentItemType
 instance Binary ContentItemType
@@ -56,7 +56,7 @@ data ContentInfo = ContentInfo {
   ,contentUrl     :: !URL
   ,contentGitUrl  :: !URL
   ,contentHtmlUrl :: !URL
-} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+} deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData ContentInfo
 instance Binary ContentInfo
@@ -64,7 +64,7 @@ instance Binary ContentInfo
 data ContentResultInfo = ContentResultInfo
     { contentResultInfo :: !ContentInfo
     , contentResultSize :: !Int
-    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    } deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData ContentResultInfo
 instance Binary ContentResultInfo
@@ -72,7 +72,7 @@ instance Binary ContentResultInfo
 data ContentResult = ContentResult
     { contentResultContent  :: !ContentResultInfo
     , contentResultCommit   :: !GitCommit
-    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    } deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData ContentResult
 instance Binary ContentResult
@@ -81,7 +81,7 @@ data Author = Author
     { authorName  :: !Text
     , authorEmail :: !Text
     }
-    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+    deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData Author
 instance Binary Author
@@ -94,7 +94,7 @@ data CreateFile = CreateFile
     , createFileAuthor    :: !(Maybe Author)
     , createFileCommitter :: !(Maybe Author)
     }
-    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+    deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData CreateFile
 instance Binary CreateFile
@@ -108,7 +108,7 @@ data UpdateFile = UpdateFile
     , updateFileAuthor    :: !(Maybe Author)
     , updateFileCommitter :: !(Maybe Author)
     }
-    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+    deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData UpdateFile
 instance Binary UpdateFile
@@ -121,7 +121,7 @@ data DeleteFile = DeleteFile
     , deleteFileAuthor    :: !(Maybe Author)
     , deleteFileCommitter :: !(Maybe Author)
     }
-    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+    deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData DeleteFile
 instance Binary DeleteFile

--- a/src/GitHub/Data/Content.hs
+++ b/src/GitHub/Data/Content.hs
@@ -20,7 +20,7 @@ data Content
   | ContentDirectory !(Vector ContentItem)
  deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Content where rnf = genericRnf
+instance NFData Content
 instance Binary Content
 
 data ContentFileData = ContentFileData {
@@ -30,7 +30,7 @@ data ContentFileData = ContentFileData {
   ,contentFileContent  :: !Text
 } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData ContentFileData where rnf = genericRnf
+instance NFData ContentFileData
 instance Binary ContentFileData
 
 -- | An item in a directory listing.
@@ -39,13 +39,13 @@ data ContentItem = ContentItem {
   ,contentItemInfo :: !ContentInfo
 } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData ContentItem where rnf = genericRnf
+instance NFData ContentItem
 instance Binary ContentItem
 
 data ContentItemType = ItemFile | ItemDir
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData ContentItemType where rnf = genericRnf
+instance NFData ContentItemType
 instance Binary ContentItemType
 
 -- | Information common to both kinds of Content: files and directories.
@@ -58,7 +58,7 @@ data ContentInfo = ContentInfo {
   ,contentHtmlUrl :: !URL
 } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData ContentInfo where rnf = genericRnf
+instance NFData ContentInfo
 instance Binary ContentInfo
 
 data ContentResultInfo = ContentResultInfo
@@ -66,7 +66,7 @@ data ContentResultInfo = ContentResultInfo
     , contentResultSize :: !Int
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData ContentResultInfo where rnf = genericRnf
+instance NFData ContentResultInfo
 instance Binary ContentResultInfo
 
 data ContentResult = ContentResult
@@ -74,7 +74,7 @@ data ContentResult = ContentResult
     , contentResultCommit   :: !GitCommit
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData ContentResult where rnf = genericRnf
+instance NFData ContentResult
 instance Binary ContentResult
 
 data Author = Author
@@ -83,7 +83,7 @@ data Author = Author
     }
     deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
-instance NFData Author where rnf = genericRnf
+instance NFData Author
 instance Binary Author
 
 data CreateFile = CreateFile
@@ -96,7 +96,7 @@ data CreateFile = CreateFile
     }
     deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
-instance NFData CreateFile where rnf = genericRnf
+instance NFData CreateFile
 instance Binary CreateFile
 
 data UpdateFile = UpdateFile
@@ -110,7 +110,7 @@ data UpdateFile = UpdateFile
     }
     deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
-instance NFData UpdateFile where rnf = genericRnf
+instance NFData UpdateFile
 instance Binary UpdateFile
 
 data DeleteFile = DeleteFile
@@ -123,7 +123,7 @@ data DeleteFile = DeleteFile
     }
     deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
-instance NFData DeleteFile where rnf = genericRnf
+instance NFData DeleteFile
 instance Binary DeleteFile
 
 instance FromJSON Content where

--- a/src/GitHub/Data/Definitions.hs
+++ b/src/GitHub/Data/Definitions.hs
@@ -22,13 +22,13 @@ data Error
     | ParseError !Text -- ^ An error in the parser itself.
     | JsonError !Text -- ^ The JSON is malformed or unexpected.
     | UserError !Text -- ^ Incorrect input.
-    deriving (Show, Typeable)
+    deriving (Show)
 
 instance E.Exception Error
 
 -- | Type of the repository owners.
 data OwnerType = OwnerUser | OwnerOrganization | OwnerBot
-    deriving (Eq, Ord, Enum, Bounded, Show, Read, Generic, Typeable, Data)
+    deriving (Eq, Ord, Enum, Bounded, Show, Read, Generic, Data)
 
 instance NFData OwnerType
 instance Binary OwnerType
@@ -39,7 +39,7 @@ data SimpleUser = SimpleUser
     , simpleUserAvatarUrl :: !URL
     , simpleUserUrl       :: !URL
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData SimpleUser
 instance Binary SimpleUser
@@ -50,7 +50,7 @@ data SimpleOrganization = SimpleOrganization
     , simpleOrganizationUrl       :: !URL
     , simpleOrganizationAvatarUrl :: !URL
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData SimpleOrganization
 instance Binary SimpleOrganization
@@ -63,7 +63,7 @@ data SimpleOwner = SimpleOwner
     , simpleOwnerAvatarUrl :: !URL
     , simpleOwnerType      :: !OwnerType
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData SimpleOwner
 instance Binary SimpleOwner
@@ -88,7 +88,7 @@ data User = User
     , userUrl         :: !URL
     , userHtmlUrl     :: !URL
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData User
 instance Binary User
@@ -111,14 +111,14 @@ data Organization = Organization
     , organizationUrl         :: !URL
     , organizationCreatedAt   :: !UTCTime
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Organization
 instance Binary Organization
 
 -- | In practice you can't have concrete values of 'Owner'.
 newtype Owner = Owner (Either User Organization)
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Owner
 instance Binary Owner
@@ -218,14 +218,14 @@ instance FromJSON Owner where
 data OrgMemberFilter
     = OrgMemberFilter2faDisabled  -- ^ Members without two-factor authentication enabled. Available for organization owners.
     | OrgMemberFilterAll          -- ^ All members the authenticated user can see.
-    deriving (Show, Eq, Ord, Enum, Bounded, Typeable, Data, Generic)
+    deriving (Show, Eq, Ord, Enum, Bounded, Data, Generic)
 
 -- | Filter members returned by their role.
 data OrgMemberRole
     = OrgMemberRoleAll     -- ^ All members of the organization, regardless of role.
     | OrgMemberRoleAdmin   -- ^ Organization owners.
     | OrgMemberRoleMember  -- ^ Non-owner organization members.
-    deriving (Show, Eq, Ord, Enum, Bounded, Typeable, Data, Generic)
+    deriving (Show, Eq, Ord, Enum, Bounded, Data, Generic)
 
 -- | Request query string
 type QueryString = [(BS.ByteString, Maybe BS.ByteString)]
@@ -240,7 +240,7 @@ data MembershipRole
     | MembershipRoleAdmin
     | MembershipRoleBillingManager
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance NFData MembershipRole
 instance Binary MembershipRole
@@ -255,7 +255,7 @@ instance FromJSON MembershipRole where
 data MembershipState
     = MembershipPending
     | MembershipActive
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData MembershipState
 instance Binary MembershipState
@@ -275,7 +275,7 @@ data Membership = Membership
     , membershipOrganization    :: !SimpleOrganization
     , membershipUser            :: !SimpleUser
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Membership
 instance Binary Membership
@@ -295,7 +295,7 @@ instance FromJSON Membership where
 -------------------------------------------------------------------------------
 
 newtype IssueNumber = IssueNumber Int
-    deriving (Eq, Ord, Show, Generic, Typeable, Data)
+    deriving (Eq, Ord, Show, Generic, Data)
 
 unIssueNumber :: IssueNumber -> Int
 unIssueNumber (IssueNumber i) = i
@@ -322,7 +322,7 @@ data IssueLabel = IssueLabel
     , labelName  :: !(Name IssueLabel)
     , labelDesc  :: !(Maybe Text)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData IssueLabel
 instance Binary IssueLabel
@@ -344,7 +344,7 @@ data NewIssueLabel = NewIssueLabel
     , newLabelName  :: !(Name NewIssueLabel)
     , newLabelDesc  :: !(Maybe Text)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewIssueLabel
 instance Binary NewIssueLabel
@@ -371,7 +371,7 @@ data UpdateIssueLabel = UpdateIssueLabel
     , updateLabelName  :: !(Name UpdateIssueLabel)
     , updateLabelDesc  :: !(Maybe Text)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData UpdateIssueLabel
 instance Binary UpdateIssueLabel

--- a/src/GitHub/Data/Definitions.hs
+++ b/src/GitHub/Data/Definitions.hs
@@ -41,7 +41,7 @@ data SimpleUser = SimpleUser
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData SimpleUser where rnf = genericRnf
+instance NFData SimpleUser
 instance Binary SimpleUser
 
 data SimpleOrganization = SimpleOrganization
@@ -52,7 +52,7 @@ data SimpleOrganization = SimpleOrganization
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData SimpleOrganization where rnf = genericRnf
+instance NFData SimpleOrganization
 instance Binary SimpleOrganization
 
 -- | Sometimes we don't know the type of the owner, e.g. in 'Repo'
@@ -65,7 +65,7 @@ data SimpleOwner = SimpleOwner
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData SimpleOwner where rnf = genericRnf
+instance NFData SimpleOwner
 instance Binary SimpleOwner
 
 data User = User
@@ -90,7 +90,7 @@ data User = User
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData User where rnf = genericRnf
+instance NFData User
 instance Binary User
 
 data Organization = Organization
@@ -113,14 +113,14 @@ data Organization = Organization
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Organization where rnf = genericRnf
+instance NFData Organization
 instance Binary Organization
 
 -- | In practice you can't have concrete values of 'Owner'.
 newtype Owner = Owner (Either User Organization)
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Owner where rnf = genericRnf
+instance NFData Owner
 instance Binary Owner
 
 fromOwner :: Owner -> Either User Organization
@@ -242,7 +242,7 @@ data MembershipRole
   deriving
     (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
 
-instance NFData MembershipRole where rnf = genericRnf
+instance NFData MembershipRole
 instance Binary MembershipRole
 
 instance FromJSON MembershipRole where
@@ -257,7 +257,7 @@ data MembershipState
     | MembershipActive
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData MembershipState where rnf = genericRnf
+instance NFData MembershipState
 instance Binary MembershipState
 
 instance FromJSON MembershipState where
@@ -277,7 +277,7 @@ data Membership = Membership
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Membership where rnf = genericRnf
+instance NFData Membership
 instance Binary Membership
 
 instance FromJSON Membership where
@@ -324,7 +324,7 @@ data IssueLabel = IssueLabel
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData IssueLabel where rnf = genericRnf
+instance NFData IssueLabel
 instance Binary IssueLabel
 
 instance FromJSON IssueLabel where
@@ -346,7 +346,7 @@ data NewIssueLabel = NewIssueLabel
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewIssueLabel where rnf = genericRnf
+instance NFData NewIssueLabel
 instance Binary NewIssueLabel
 
 
@@ -373,7 +373,7 @@ data UpdateIssueLabel = UpdateIssueLabel
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData UpdateIssueLabel where rnf = genericRnf
+instance NFData UpdateIssueLabel
 instance Binary UpdateIssueLabel
 
 

--- a/src/GitHub/Data/DeployKeys.hs
+++ b/src/GitHub/Data/DeployKeys.hs
@@ -19,7 +19,7 @@ data RepoDeployKey = RepoDeployKey
     , repoDeployKeyCreatedAt :: !UTCTime
     , repoDeployKeyReadOnly  :: !Bool
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance FromJSON RepoDeployKey where
     parseJSON = withObject "RepoDeployKey" $ \o -> RepoDeployKey
@@ -36,7 +36,7 @@ data NewRepoDeployKey = NewRepoDeployKey
     , newRepoDeployKeyTitle    :: !Text
     , newRepoDeployKeyReadOnly :: !Bool
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance ToJSON NewRepoDeployKey where
     toJSON (NewRepoDeployKey key title readOnly) = object

--- a/src/GitHub/Data/Deployments.hs
+++ b/src/GitHub/Data/Deployments.hs
@@ -34,7 +34,7 @@ data DeploymentQueryOption
     | DeploymentQueryRef         !Text
     | DeploymentQueryTask        !Text
     | DeploymentQueryEnvironment !Text
-      deriving (Show, Data, Typeable, Eq, Ord, Generic)
+      deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData DeploymentQueryOption
 instance Binary DeploymentQueryOption
@@ -61,7 +61,7 @@ data Deployment a = Deployment
     , deploymentUpdatedAt     :: !UTCTime
     , deploymentStatusesUrl   :: !URL
     , deploymentRepositoryUrl :: !URL
-    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    } deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData a => NFData (Deployment a)
 instance Binary a => Binary (Deployment a)
@@ -104,7 +104,7 @@ data CreateDeployment a = CreateDeployment
     -- qa). Default: production
     , createDeploymentDescription      :: !(Maybe Text)
     -- ^ Short description of the deployment. Default: ""
-    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    } deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData a => NFData (CreateDeployment a)
 instance Binary a => Binary (CreateDeployment a)
@@ -132,7 +132,7 @@ data DeploymentStatus = DeploymentStatus
     , deploymentStatusUpdatedAt     :: !UTCTime
     , deploymentStatusDeploymentUrl :: !URL
     , deploymentStatusRepositoryUrl :: !URL
-    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    } deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData DeploymentStatus
 instance Binary DeploymentStatus
@@ -157,7 +157,7 @@ data DeploymentStatusState
     | DeploymentStatusPending
     | DeploymentStatusSuccess
     | DeploymentStatusInactive
-      deriving (Show, Data, Typeable, Eq, Ord, Generic)
+      deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData DeploymentStatusState
 instance Binary DeploymentStatusState
@@ -190,7 +190,7 @@ data CreateDeploymentStatus = CreateDeploymentStatus
     , createDeploymentStatusDescription :: !(Maybe Text)
     -- ^ A short description of the status. Maximum length of 140 characters.
     -- Default: ""
-    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    } deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData CreateDeploymentStatus
 instance Binary CreateDeploymentStatus

--- a/src/GitHub/Data/Deployments.hs
+++ b/src/GitHub/Data/Deployments.hs
@@ -36,7 +36,7 @@ data DeploymentQueryOption
     | DeploymentQueryEnvironment !Text
       deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData DeploymentQueryOption where rnf = genericRnf
+instance NFData DeploymentQueryOption
 instance Binary DeploymentQueryOption
 
 renderDeploymentQueryOption :: DeploymentQueryOption -> (ByteString, ByteString)
@@ -63,7 +63,7 @@ data Deployment a = Deployment
     , deploymentRepositoryUrl :: !URL
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData a => NFData (Deployment a) where rnf = genericRnf
+instance NFData a => NFData (Deployment a)
 instance Binary a => Binary (Deployment a)
 
 instance FromJSON a => FromJSON (Deployment a) where
@@ -106,7 +106,7 @@ data CreateDeployment a = CreateDeployment
     -- ^ Short description of the deployment. Default: ""
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData a => NFData (CreateDeployment a) where rnf = genericRnf
+instance NFData a => NFData (CreateDeployment a)
 instance Binary a => Binary (CreateDeployment a)
 
 instance ToJSON a => ToJSON (CreateDeployment a) where
@@ -134,7 +134,7 @@ data DeploymentStatus = DeploymentStatus
     , deploymentStatusRepositoryUrl :: !URL
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData DeploymentStatus where rnf = genericRnf
+instance NFData DeploymentStatus
 instance Binary DeploymentStatus
 
 instance FromJSON DeploymentStatus where
@@ -159,7 +159,7 @@ data DeploymentStatusState
     | DeploymentStatusInactive
       deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData DeploymentStatusState where rnf = genericRnf
+instance NFData DeploymentStatusState
 instance Binary DeploymentStatusState
 
 instance ToJSON DeploymentStatusState where
@@ -192,7 +192,7 @@ data CreateDeploymentStatus = CreateDeploymentStatus
     -- Default: ""
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData CreateDeploymentStatus where rnf = genericRnf
+instance NFData CreateDeploymentStatus
 instance Binary CreateDeploymentStatus
 
 instance ToJSON CreateDeploymentStatus where

--- a/src/GitHub/Data/Email.hs
+++ b/src/GitHub/Data/Email.hs
@@ -8,7 +8,7 @@ import qualified Data.Text as T
 data EmailVisibility
     = EmailVisibilityPrivate
     | EmailVisibilityPublic
-    deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Enum, Bounded, Eq, Ord, Generic)
 
 instance NFData EmailVisibility
 instance Binary EmailVisibility
@@ -24,7 +24,7 @@ data Email = Email
     , emailVerified   :: !Bool
     , emailPrimary    :: !Bool
     , emailVisibility :: !(Maybe EmailVisibility)
-    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    } deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Email
 instance Binary Email

--- a/src/GitHub/Data/Email.hs
+++ b/src/GitHub/Data/Email.hs
@@ -10,7 +10,7 @@ data EmailVisibility
     | EmailVisibilityPublic
     deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
 
-instance NFData EmailVisibility where rnf = genericRnf
+instance NFData EmailVisibility
 instance Binary EmailVisibility
 
 instance FromJSON EmailVisibility where
@@ -26,7 +26,7 @@ data Email = Email
     , emailVisibility :: !(Maybe EmailVisibility)
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Email where rnf = genericRnf
+instance NFData Email
 instance Binary Email
 
 instance FromJSON Email where

--- a/src/GitHub/Data/Enterprise/Organizations.hs
+++ b/src/GitHub/Data/Enterprise/Organizations.hs
@@ -13,7 +13,7 @@ data CreateOrganization = CreateOrganization
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData CreateOrganization where rnf = genericRnf
+instance NFData CreateOrganization
 instance Binary CreateOrganization
 
 data RenameOrganization = RenameOrganization
@@ -21,7 +21,7 @@ data RenameOrganization = RenameOrganization
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RenameOrganization where rnf = genericRnf
+instance NFData RenameOrganization
 instance Binary RenameOrganization
 
 data RenameOrganizationResponse = RenameOrganizationResponse
@@ -30,7 +30,7 @@ data RenameOrganizationResponse = RenameOrganizationResponse
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RenameOrganizationResponse where rnf = genericRnf
+instance NFData RenameOrganizationResponse
 instance Binary RenameOrganizationResponse
 
 -- JSON Instances

--- a/src/GitHub/Data/Enterprise/Organizations.hs
+++ b/src/GitHub/Data/Enterprise/Organizations.hs
@@ -11,7 +11,7 @@ data CreateOrganization = CreateOrganization
     , createOrganizationAdmin       :: !(Name User)
     , createOrganizationProfileName :: !(Maybe Text)
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData CreateOrganization
 instance Binary CreateOrganization
@@ -19,7 +19,7 @@ instance Binary CreateOrganization
 data RenameOrganization = RenameOrganization
     { renameOrganizationLogin :: !(Name Organization)
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RenameOrganization
 instance Binary RenameOrganization
@@ -28,7 +28,7 @@ data RenameOrganizationResponse = RenameOrganizationResponse
     { renameOrganizationResponseMessage :: !Text
     , renameOrganizationResponseUrl     :: !URL
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RenameOrganizationResponse
 instance Binary RenameOrganizationResponse

--- a/src/GitHub/Data/Events.hs
+++ b/src/GitHub/Data/Events.hs
@@ -18,7 +18,7 @@ data Event = Event
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Event where rnf = genericRnf
+instance NFData Event
 instance Binary Event
 
 instance FromJSON Event where

--- a/src/GitHub/Data/Events.hs
+++ b/src/GitHub/Data/Events.hs
@@ -16,7 +16,7 @@ data Event = Event
     , eventCreatedAt :: !UTCTime
     , eventPublic    :: !Bool
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Event
 instance Binary Event

--- a/src/GitHub/Data/Gists.hs
+++ b/src/GitHub/Data/Gists.hs
@@ -23,7 +23,7 @@ data Gist = Gist
     , gistGitPullUrl  :: !URL
     } deriving (Show, Data, Typeable, Eq, Generic)
 
-instance NFData Gist where rnf = genericRnf
+instance NFData Gist
 instance Binary Gist
 
 instance FromJSON Gist where
@@ -51,7 +51,7 @@ data GistFile = GistFile
     }
   deriving (Show, Data, Typeable, Eq, Generic)
 
-instance NFData GistFile where rnf = genericRnf
+instance NFData GistFile
 instance Binary GistFile
 
 instance FromJSON GistFile where
@@ -73,7 +73,7 @@ data GistComment = GistComment
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData GistComment where rnf = genericRnf
+instance NFData GistComment
 instance Binary GistComment
 
 instance FromJSON GistComment where
@@ -91,7 +91,7 @@ data NewGist = NewGist
     , newGistPublic      :: !(Maybe Bool)
     } deriving (Show, Data, Typeable, Eq, Generic)
 
-instance NFData NewGist where rnf = genericRnf
+instance NFData NewGist
 instance Binary NewGist
 
 instance ToJSON NewGist where
@@ -111,7 +111,7 @@ data NewGistFile = NewGistFile
     { newGistFileContent :: !Text
     } deriving (Show, Data, Typeable, Eq, Generic)
 
-instance NFData NewGistFile where rnf = genericRnf
+instance NFData NewGistFile
 instance Binary NewGistFile
 
 instance ToJSON NewGistFile where

--- a/src/GitHub/Data/Gists.hs
+++ b/src/GitHub/Data/Gists.hs
@@ -21,7 +21,7 @@ data Gist = Gist
     , gistId          :: !(Name Gist)
     , gistFiles       :: !(HashMap Text GistFile)
     , gistGitPullUrl  :: !URL
-    } deriving (Show, Data, Typeable, Eq, Generic)
+    } deriving (Show, Data, Eq, Generic)
 
 instance NFData Gist
 instance Binary Gist
@@ -49,7 +49,7 @@ data GistFile = GistFile
     , gistFileFilename :: !Text
     , gistFileContent  :: !(Maybe Text)
     }
-  deriving (Show, Data, Typeable, Eq, Generic)
+  deriving (Show, Data, Eq, Generic)
 
 instance NFData GistFile
 instance Binary GistFile
@@ -71,7 +71,7 @@ data GistComment = GistComment
     , gistCommentUpdatedAt :: !UTCTime
     , gistCommentId        :: !(Id GistComment)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData GistComment
 instance Binary GistComment
@@ -89,7 +89,7 @@ data NewGist = NewGist
     { newGistDescription :: !(Maybe Text)
     , newGistFiles       :: !(HashMap Text NewGistFile)
     , newGistPublic      :: !(Maybe Bool)
-    } deriving (Show, Data, Typeable, Eq, Generic)
+    } deriving (Show, Data, Eq, Generic)
 
 instance NFData NewGist
 instance Binary NewGist
@@ -109,7 +109,7 @@ instance ToJSON NewGist where
 
 data NewGistFile = NewGistFile
     { newGistFileContent :: !Text
-    } deriving (Show, Data, Typeable, Eq, Generic)
+    } deriving (Show, Data, Eq, Generic)
 
 instance NFData NewGistFile
 instance Binary NewGistFile

--- a/src/GitHub/Data/GitData.hs
+++ b/src/GitHub/Data/GitData.hs
@@ -24,7 +24,7 @@ data Stats = Stats
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Stats where rnf = genericRnf
+instance NFData Stats
 instance Binary Stats
 
 data Commit = Commit
@@ -39,7 +39,7 @@ data Commit = Commit
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Commit where rnf = genericRnf
+instance NFData Commit
 instance Binary Commit
 
 data Tree = Tree
@@ -49,7 +49,7 @@ data Tree = Tree
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Tree where rnf = genericRnf
+instance NFData Tree
 instance Binary Tree
 
 data GitTree = GitTree
@@ -63,7 +63,7 @@ data GitTree = GitTree
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData GitTree where rnf = genericRnf
+instance NFData GitTree
 instance Binary GitTree
 
 data GitCommit = GitCommit
@@ -77,7 +77,7 @@ data GitCommit = GitCommit
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData GitCommit where rnf = genericRnf
+instance NFData GitCommit
 instance Binary GitCommit
 
 data Blob = Blob
@@ -89,7 +89,7 @@ data Blob = Blob
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Blob where rnf = genericRnf
+instance NFData Blob
 instance Binary Blob
 
 data Tag = Tag
@@ -100,7 +100,7 @@ data Tag = Tag
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Tag where rnf = genericRnf
+instance NFData Tag
 instance Binary Tag
 
 data Branch = Branch
@@ -109,7 +109,7 @@ data Branch = Branch
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Branch where rnf = genericRnf
+instance NFData Branch
 
 data BranchCommit = BranchCommit
     { branchCommitSha :: !Text
@@ -117,7 +117,7 @@ data BranchCommit = BranchCommit
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData BranchCommit where rnf = genericRnf
+instance NFData BranchCommit
 instance Binary BranchCommit
 
 data Diff = Diff
@@ -136,7 +136,7 @@ data Diff = Diff
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Diff where rnf = genericRnf
+instance NFData Diff
 instance Binary Diff
 
 data NewGitReference = NewGitReference
@@ -145,7 +145,7 @@ data NewGitReference = NewGitReference
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewGitReference where rnf = genericRnf
+instance NFData NewGitReference
 instance Binary NewGitReference
 
 data GitReference = GitReference
@@ -155,7 +155,7 @@ data GitReference = GitReference
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData GitReference where rnf = genericRnf
+instance NFData GitReference
 instance Binary GitReference
 
 data GitObject = GitObject
@@ -165,7 +165,7 @@ data GitObject = GitObject
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData GitObject where rnf = genericRnf
+instance NFData GitObject
 instance Binary GitObject
 
 data GitUser = GitUser
@@ -175,7 +175,7 @@ data GitUser = GitUser
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData GitUser where rnf = genericRnf
+instance NFData GitUser
 instance Binary GitUser
 
 data File = File
@@ -191,7 +191,7 @@ data File = File
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData File where rnf = genericRnf
+instance NFData File
 instance Binary File
 
 -- JSON instances

--- a/src/GitHub/Data/GitData.hs
+++ b/src/GitHub/Data/GitData.hs
@@ -15,14 +15,14 @@ data CommitQueryOption
     | CommitQueryAuthor !Text
     | CommitQuerySince !UTCTime
     | CommitQueryUntil !UTCTime
-  deriving (Show, Eq, Ord, Generic, Typeable, Data)
+  deriving (Show, Eq, Ord, Generic, Data)
 
 data Stats = Stats
     { statsAdditions :: !Int
     , statsTotal     :: !Int
     , statsDeletions :: !Int
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Stats
 instance Binary Stats
@@ -37,7 +37,7 @@ data Commit = Commit
     , commitFiles     :: !(Vector File)
     , commitStats     :: !(Maybe Stats)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Commit
 instance Binary Commit
@@ -47,7 +47,7 @@ data Tree = Tree
     , treeUrl      :: !URL
     , treeGitTrees :: !(Vector GitTree)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Tree
 instance Binary Tree
@@ -61,7 +61,7 @@ data GitTree = GitTree
     , gitTreePath :: !Text
     , gitTreeMode :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData GitTree
 instance Binary GitTree
@@ -75,7 +75,7 @@ data GitCommit = GitCommit
     , gitCommitSha       :: !(Maybe (Name GitCommit))
     , gitCommitParents   :: !(Vector Tree)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData GitCommit
 instance Binary GitCommit
@@ -87,7 +87,7 @@ data Blob = Blob
     , blobSha      :: !(Name Blob)
     , blobSize     :: !Int
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Blob
 instance Binary Blob
@@ -98,7 +98,7 @@ data Tag = Tag
     , tagTarballUrl :: !URL
     , tagCommit     :: !BranchCommit
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Tag
 instance Binary Tag
@@ -107,7 +107,7 @@ data Branch = Branch
     { branchName   :: !Text
     , branchCommit :: !BranchCommit
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Branch
 
@@ -115,7 +115,7 @@ data BranchCommit = BranchCommit
     { branchCommitSha :: !Text
     , branchCommitUrl :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData BranchCommit
 instance Binary BranchCommit
@@ -134,7 +134,7 @@ data Diff = Diff
     , diffDiffUrl      :: !URL
     , diffPermalinkUrl :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Diff
 instance Binary Diff
@@ -143,7 +143,7 @@ data NewGitReference = NewGitReference
     { newGitReferenceRef :: !Text
     , newGitReferenceSha :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewGitReference
 instance Binary NewGitReference
@@ -153,7 +153,7 @@ data GitReference = GitReference
     , gitReferenceUrl    :: !URL
     , gitReferenceRef    :: !(Name GitReference)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData GitReference
 instance Binary GitReference
@@ -163,7 +163,7 @@ data GitObject = GitObject
     , gitObjectSha  :: !Text
     , gitObjectUrl  :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData GitObject
 instance Binary GitObject
@@ -173,7 +173,7 @@ data GitUser = GitUser
     , gitUserEmail :: !Text
     , gitUserDate  :: !UTCTime
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData GitUser
 instance Binary GitUser
@@ -189,7 +189,7 @@ data File = File
     , fileFilename  :: !Text
     , fileDeletions :: !Int
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData File
 instance Binary File

--- a/src/GitHub/Data/Id.hs
+++ b/src/GitHub/Data/Id.hs
@@ -9,7 +9,7 @@ import Prelude ()
 
 -- | Numeric identifier.
 newtype Id entity = Id Int
-    deriving (Eq, Ord, Show, Generic, Typeable, Data)
+    deriving (Eq, Ord, Show, Generic, Data)
 
 -- | Smart constructor for 'Id'.
 mkId :: proxy entity -> Int -> Id entity

--- a/src/GitHub/Data/Invitation.hs
+++ b/src/GitHub/Data/Invitation.hs
@@ -21,7 +21,7 @@ data Invitation = Invitation
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Invitation where rnf = genericRnf
+instance NFData Invitation
 instance Binary Invitation
 
 instance FromJSON Invitation where
@@ -43,7 +43,7 @@ data InvitationRole
   deriving
     (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
 
-instance NFData InvitationRole where rnf = genericRnf
+instance NFData InvitationRole
 instance Binary InvitationRole
 
 instance FromJSON InvitationRole where
@@ -67,7 +67,7 @@ data RepoInvitation = RepoInvitation
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RepoInvitation where rnf = genericRnf
+instance NFData RepoInvitation
 instance Binary RepoInvitation
 
 instance FromJSON RepoInvitation where

--- a/src/GitHub/Data/Invitation.hs
+++ b/src/GitHub/Data/Invitation.hs
@@ -19,7 +19,7 @@ data Invitation = Invitation
     , invitationCreatedAt :: !UTCTime
     , inviter             :: !SimpleUser
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Invitation
 instance Binary Invitation
@@ -41,7 +41,7 @@ data InvitationRole
     | InvitationRoleHiringManager
     | InvitationRoleReinstate
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance NFData InvitationRole
 instance Binary InvitationRole
@@ -65,7 +65,7 @@ data RepoInvitation = RepoInvitation
     , repoInvitationPermission :: !Text
     , repoInvitationHtmlUrl    :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RepoInvitation
 instance Binary RepoInvitation

--- a/src/GitHub/Data/Issues.hs
+++ b/src/GitHub/Data/Issues.hs
@@ -33,7 +33,7 @@ data Issue = Issue
     , issueMilestone   :: !(Maybe Milestone)
     , issueStateReason :: !(Maybe IssueStateReason)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Issue
 instance Binary Issue
@@ -45,7 +45,7 @@ data NewIssue = NewIssue
     , newIssueMilestone :: !(Maybe (Id Milestone))
     , newIssueLabels    :: !(Maybe (Vector (Name IssueLabel)))
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewIssue
 instance Binary NewIssue
@@ -58,7 +58,7 @@ data EditIssue = EditIssue
     , editIssueMilestone :: !(Maybe (Id Milestone))
     , editIssueLabels    :: !(Maybe (Vector (Name IssueLabel)))
     }
-  deriving  (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving  (Show, Data, Eq, Ord, Generic)
 
 instance NFData EditIssue
 instance Binary EditIssue
@@ -72,7 +72,7 @@ data IssueComment = IssueComment
     , issueCommentBody      :: !Text
     , issueCommentId        :: !Int
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData IssueComment
 instance Binary IssueComment
@@ -106,7 +106,7 @@ data EventType
     | MovedColumnsInProject -- ^ The issue was moved between columns in a project board.
     | RemovedFromProject    -- ^ The issue was removed from a project board.
     | ConvertedNoteToIssue  -- ^ The issue was created by converting a note in a project board to an issue.
-  deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Enum, Bounded, Eq, Ord, Generic)
 
 instance NFData EventType
 instance Binary EventType
@@ -122,7 +122,7 @@ data IssueEvent = IssueEvent
     , issueEventIssue     :: !(Maybe Issue)
     , issueEventLabel     :: !(Maybe IssueLabel)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData IssueEvent
 instance Binary IssueEvent

--- a/src/GitHub/Data/Issues.hs
+++ b/src/GitHub/Data/Issues.hs
@@ -35,7 +35,7 @@ data Issue = Issue
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Issue where rnf = genericRnf
+instance NFData Issue
 instance Binary Issue
 
 data NewIssue = NewIssue
@@ -47,7 +47,7 @@ data NewIssue = NewIssue
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewIssue where rnf = genericRnf
+instance NFData NewIssue
 instance Binary NewIssue
 
 data EditIssue = EditIssue
@@ -60,7 +60,7 @@ data EditIssue = EditIssue
     }
   deriving  (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData EditIssue where rnf = genericRnf
+instance NFData EditIssue
 instance Binary EditIssue
 
 data IssueComment = IssueComment
@@ -74,7 +74,7 @@ data IssueComment = IssueComment
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData IssueComment where rnf = genericRnf
+instance NFData IssueComment
 instance Binary IssueComment
 
 -- | See <https://developer.github.com/v3/issues/events/#events-1>
@@ -108,7 +108,7 @@ data EventType
     | ConvertedNoteToIssue  -- ^ The issue was created by converting a note in a project board to an issue.
   deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
 
-instance NFData EventType where rnf = genericRnf
+instance NFData EventType
 instance Binary EventType
 
 -- | Issue event
@@ -124,7 +124,7 @@ data IssueEvent = IssueEvent
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData IssueEvent where rnf = genericRnf
+instance NFData IssueEvent
 instance Binary IssueEvent
 
 instance FromJSON IssueEvent where

--- a/src/GitHub/Data/Milestone.hs
+++ b/src/GitHub/Data/Milestone.hs
@@ -20,7 +20,7 @@ data Milestone = Milestone
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Milestone where rnf = genericRnf
+instance NFData Milestone
 instance Binary Milestone
 
 instance FromJSON Milestone where
@@ -44,7 +44,7 @@ data NewMilestone = NewMilestone
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewMilestone where rnf = genericRnf
+instance NFData NewMilestone
 instance Binary NewMilestone
 
 
@@ -67,7 +67,7 @@ data UpdateMilestone = UpdateMilestone
   }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData UpdateMilestone where rnf = genericRnf
+instance NFData UpdateMilestone
 instance Binary UpdateMilestone
 
 

--- a/src/GitHub/Data/Milestone.hs
+++ b/src/GitHub/Data/Milestone.hs
@@ -18,7 +18,7 @@ data Milestone = Milestone
     , milestoneCreatedAt    :: !UTCTime
     , milestoneState        :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Milestone
 instance Binary Milestone
@@ -42,7 +42,7 @@ data NewMilestone = NewMilestone
     , newMilestoneDescription :: !(Maybe Text)
     , newMilestoneDueOn       :: !(Maybe UTCTime)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewMilestone
 instance Binary NewMilestone
@@ -65,7 +65,7 @@ data UpdateMilestone = UpdateMilestone
   , updateMilestoneDescription :: !(Maybe Text)
   , updateMilestoneDueOn       :: !(Maybe UTCTime)
   }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData UpdateMilestone
 instance Binary UpdateMilestone

--- a/src/GitHub/Data/Name.hs
+++ b/src/GitHub/Data/Name.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Types
        (FromJSONKey (..), ToJSONKey (..), fromJSONKeyCoerce, toJSONKeyText)
 
 newtype Name entity = N Text
-    deriving (Eq, Ord, Show, Generic, Typeable, Data)
+    deriving (Eq, Ord, Show, Generic, Data)
 
 -- | Smart constructor for 'Name'
 mkName :: proxy entity -> Text -> Name entity

--- a/src/GitHub/Data/Options.hs
+++ b/src/GitHub/Data/Options.hs
@@ -116,7 +116,7 @@ instance FromJSON IssueState where
         "closed" -> pure StateClosed
         _        -> fail $ "Unknown IssueState: " <> T.unpack t
 
-instance NFData IssueState where rnf = genericRnf
+instance NFData IssueState
 instance Binary IssueState
 
 -- | 'GitHub.Data.Issues.Issue' state reason
@@ -143,7 +143,7 @@ instance FromJSON IssueStateReason where
         "reopened"    -> pure StateReasonReopened
         _ -> fail $ "Unknown IssueStateReason: " <> T.unpack t
 
-instance NFData IssueStateReason where rnf = genericRnf
+instance NFData IssueStateReason
 instance Binary IssueStateReason
 
 -- | 'GitHub.Data.PullRequests.PullRequest' mergeable_state
@@ -178,7 +178,7 @@ instance FromJSON MergeableState where
         "draft"    -> pure StateDraft
         _          -> fail $ "Unknown MergeableState: " <> T.unpack t
 
-instance NFData MergeableState where rnf = genericRnf
+instance NFData MergeableState
 instance Binary MergeableState
 
 data SortDirection
@@ -187,7 +187,7 @@ data SortDirection
   deriving
     (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
 
-instance NFData SortDirection where rnf = genericRnf
+instance NFData SortDirection
 instance Binary SortDirection
 
 -- PR
@@ -200,7 +200,7 @@ data SortPR
   deriving
     (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
 
-instance NFData SortPR where rnf = genericRnf
+instance NFData SortPR
 instance Binary SortPR
 
 -- Issue
@@ -213,7 +213,7 @@ data IssueFilter
   deriving
     (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
 
-instance NFData IssueFilter where rnf = genericRnf
+instance NFData IssueFilter
 instance Binary IssueFilter
 
 data SortIssue
@@ -223,7 +223,7 @@ data SortIssue
   deriving
     (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
 
-instance NFData SortIssue where rnf = genericRnf
+instance NFData SortIssue
 instance Binary SortIssue
 
 data FilterBy a
@@ -245,7 +245,7 @@ data SortCache
   deriving
     (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
 
-instance NFData SortCache where rnf = genericRnf
+instance NFData SortCache
 instance Binary SortCache
 
 -------------------------------------------------------------------------------

--- a/src/GitHub/Data/Options.hs
+++ b/src/GitHub/Data/Options.hs
@@ -104,7 +104,7 @@ data IssueState
     = StateOpen
     | StateClosed
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance ToJSON IssueState where
     toJSON StateOpen    = String "open"
@@ -126,7 +126,7 @@ data IssueStateReason
     | StateReasonNotPlanned
     | StateReasonReopened
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance ToJSON IssueStateReason where
     toJSON = String . \case
@@ -156,7 +156,7 @@ data MergeableState
     | StateBehind
     | StateDraft
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance ToJSON MergeableState where
     toJSON StateUnknown  = String "unknown"
@@ -185,7 +185,7 @@ data SortDirection
     = SortAscending
     | SortDescending
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance NFData SortDirection
 instance Binary SortDirection
@@ -198,7 +198,7 @@ data SortPR
     | SortPRPopularity
     | SortPRLongRunning
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance NFData SortPR
 instance Binary SortPR
@@ -211,7 +211,7 @@ data IssueFilter
     | IssueFilterSubscribed
     | IssueFilterAll
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance NFData IssueFilter
 instance Binary IssueFilter
@@ -221,7 +221,7 @@ data SortIssue
     | SortIssueUpdated
     | SortIssueComments
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance NFData SortIssue
 instance Binary SortIssue
@@ -234,7 +234,7 @@ data FilterBy a
       -- ^ e.g. for milestones "any" means "any milestone".
       -- I.e. won't show issues without mileston specified
   deriving
-    (Eq, Ord, Show, Generic, Typeable, Data)
+    (Eq, Ord, Show, Generic, Data)
 
 -- Actions cache
 
@@ -243,7 +243,7 @@ data SortCache
     | SortCacheLastAccessedAt
     | SortCacheSizeInBytes
   deriving
-    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+    (Eq, Ord, Show, Enum, Bounded, Generic, Data)
 
 instance NFData SortCache
 instance Binary SortCache
@@ -334,7 +334,7 @@ data PullRequestOptions = PullRequestOptions
     , pullRequestOptionsDirection :: !SortDirection
     }
   deriving
-    (Eq, Ord, Show, Generic, Typeable, Data)
+    (Eq, Ord, Show, Generic, Data)
 
 defaultPullRequestOptions :: PullRequestOptions
 defaultPullRequestOptions = PullRequestOptions
@@ -429,7 +429,7 @@ data IssueOptions = IssueOptions
     , issueOptionsSince     :: !(Maybe UTCTime)
     }
   deriving
-    (Eq, Ord, Show, Generic, Typeable, Data)
+    (Eq, Ord, Show, Generic, Data)
 
 defaultIssueOptions :: IssueOptions
 defaultIssueOptions = IssueOptions
@@ -575,7 +575,7 @@ data IssueRepoOptions = IssueRepoOptions
     , issueRepoOptionsSince     :: !(Maybe UTCTime)             -- ^ 'HasSince'
     }
   deriving
-    (Eq, Ord, Show, Generic, Typeable, Data)
+    (Eq, Ord, Show, Generic, Data)
 
 defaultIssueRepoOptions :: IssueRepoOptions
 defaultIssueRepoOptions = IssueRepoOptions
@@ -714,7 +714,7 @@ data ArtifactOptions = ArtifactOptions
     { artifactOptionsName :: !(Maybe Text)
     }
   deriving
-    (Eq, Ord, Show, Generic, Typeable, Data)
+    (Eq, Ord, Show, Generic, Data)
 
 defaultArtifactOptions :: ArtifactOptions
 defaultArtifactOptions = ArtifactOptions
@@ -763,7 +763,7 @@ data CacheOptions = CacheOptions
     , cacheOptionsDirection :: !(Maybe SortDirection)
     }
   deriving
-    (Eq, Ord, Show, Generic, Typeable, Data)
+    (Eq, Ord, Show, Generic, Data)
 
 defaultCacheOptions :: CacheOptions
 defaultCacheOptions = CacheOptions
@@ -863,7 +863,7 @@ data WorkflowRunOptions = WorkflowRunOptions
     , workflowRunOptionsHeadSha :: !(Maybe Text)
     }
   deriving
-    (Eq, Ord, Show, Generic, Typeable, Data)
+    (Eq, Ord, Show, Generic, Data)
 
 defaultWorkflowRunOptions :: WorkflowRunOptions
 defaultWorkflowRunOptions = WorkflowRunOptions

--- a/src/GitHub/Data/PublicSSHKeys.hs
+++ b/src/GitHub/Data/PublicSSHKeys.hs
@@ -14,7 +14,7 @@ data PublicSSHKeyBasic = PublicSSHKeyBasic
     { basicPublicSSHKeyId        :: !(Id PublicSSHKey)
     , basicPublicSSHKeyKey       :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance FromJSON PublicSSHKeyBasic where
     parseJSON = withObject "PublicSSHKeyBasic" $ \o -> PublicSSHKeyBasic
@@ -30,7 +30,7 @@ data PublicSSHKey = PublicSSHKey
     , publicSSHKeyCreatedAt :: !(Maybe UTCTime)
     , publicSSHKeyReadOnly  :: !Bool
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance FromJSON PublicSSHKey where
     parseJSON = withObject "PublicSSHKey" $ \o -> PublicSSHKey
@@ -46,7 +46,7 @@ data NewPublicSSHKey = NewPublicSSHKey
     { newPublicSSHKeyKey      :: !Text
     , newPublicSSHKeyTitle    :: !Text
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance ToJSON NewPublicSSHKey where
     toJSON (NewPublicSSHKey key title) = object

--- a/src/GitHub/Data/PullRequests.hs
+++ b/src/GitHub/Data/PullRequests.hs
@@ -43,7 +43,7 @@ data SimplePullRequest = SimplePullRequest
     , simplePullRequestTitle              :: !Text
     , simplePullRequestId                 :: !(Id PullRequest)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData SimplePullRequest
 instance Binary SimplePullRequest
@@ -81,7 +81,7 @@ data PullRequest = PullRequest
     , pullRequestMergeable            :: !(Maybe Bool)
     , pullRequestMergeableState       :: !MergeableState
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData PullRequest
 instance Binary PullRequest
@@ -122,7 +122,7 @@ data PullRequestLinks = PullRequestLinks
     , pullRequestLinksHtml           :: !URL
     , pullRequestLinksSelf           :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData PullRequestLinks
 instance Binary PullRequestLinks
@@ -134,7 +134,7 @@ data PullRequestCommit = PullRequestCommit
     , pullRequestCommitUser  :: !SimpleUser
     , pullRequestCommitRepo  :: !(Maybe Repo)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData PullRequestCommit
 instance Binary PullRequestCommit
@@ -146,7 +146,7 @@ data PullRequestEvent = PullRequestEvent
     , pullRequestRepository       :: !Repo
     , pullRequestSender           :: !SimpleUser
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData PullRequestEvent
 instance Binary PullRequestEvent
@@ -163,7 +163,7 @@ data PullRequestEventType
     | PullRequestReviewRequested
     | PullRequestReviewRequestRemoved
     | PullRequestEdited
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData PullRequestEventType
 instance Binary PullRequestEventType
@@ -173,7 +173,7 @@ data PullRequestReference = PullRequestReference
     , pullRequestReferencePatchUrl :: !(Maybe URL)
     , pullRequestReferenceDiffUrl  :: !(Maybe URL)
     }
-    deriving (Eq, Ord, Show, Generic, Typeable, Data)
+    deriving (Eq, Ord, Show, Generic, Data)
 
 instance NFData PullRequestReference
 instance Binary PullRequestReference
@@ -316,4 +316,4 @@ data MergeResult
     = MergeSuccessful
     | MergeCannotPerform
     | MergeConflict
-  deriving (Eq, Ord, Read, Show, Enum, Bounded, Generic, Typeable)
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Generic)

--- a/src/GitHub/Data/PullRequests.hs
+++ b/src/GitHub/Data/PullRequests.hs
@@ -45,7 +45,7 @@ data SimplePullRequest = SimplePullRequest
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData SimplePullRequest where rnf = genericRnf
+instance NFData SimplePullRequest
 instance Binary SimplePullRequest
 
 data PullRequest = PullRequest
@@ -83,7 +83,7 @@ data PullRequest = PullRequest
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData PullRequest where rnf = genericRnf
+instance NFData PullRequest
 instance Binary PullRequest
 
 data EditPullRequest = EditPullRequest
@@ -96,7 +96,7 @@ data EditPullRequest = EditPullRequest
     }
   deriving (Show, Generic)
 
-instance NFData EditPullRequest where rnf = genericRnf
+instance NFData EditPullRequest
 instance Binary EditPullRequest
 
 data CreatePullRequest
@@ -113,7 +113,7 @@ data CreatePullRequest
       }
   deriving (Show, Generic)
 
-instance NFData CreatePullRequest where rnf = genericRnf
+instance NFData CreatePullRequest
 instance Binary CreatePullRequest
 
 data PullRequestLinks = PullRequestLinks
@@ -124,7 +124,7 @@ data PullRequestLinks = PullRequestLinks
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData PullRequestLinks where rnf = genericRnf
+instance NFData PullRequestLinks
 instance Binary PullRequestLinks
 
 data PullRequestCommit = PullRequestCommit
@@ -136,7 +136,7 @@ data PullRequestCommit = PullRequestCommit
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData PullRequestCommit where rnf = genericRnf
+instance NFData PullRequestCommit
 instance Binary PullRequestCommit
 
 data PullRequestEvent = PullRequestEvent
@@ -148,7 +148,7 @@ data PullRequestEvent = PullRequestEvent
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData PullRequestEvent where rnf = genericRnf
+instance NFData PullRequestEvent
 instance Binary PullRequestEvent
 
 data PullRequestEventType
@@ -165,7 +165,7 @@ data PullRequestEventType
     | PullRequestEdited
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData PullRequestEventType where rnf = genericRnf
+instance NFData PullRequestEventType
 instance Binary PullRequestEventType
 
 data PullRequestReference = PullRequestReference
@@ -175,7 +175,7 @@ data PullRequestReference = PullRequestReference
     }
     deriving (Eq, Ord, Show, Generic, Typeable, Data)
 
-instance NFData PullRequestReference where rnf = genericRnf
+instance NFData PullRequestReference
 instance Binary PullRequestReference
 
 

--- a/src/GitHub/Data/RateLimit.hs
+++ b/src/GitHub/Data/RateLimit.hs
@@ -15,7 +15,7 @@ data Limits = Limits
     }
   deriving (Show, {- Data, -} Typeable, Eq, Ord, Generic)
 
-instance NFData Limits where rnf = genericRnf
+instance NFData Limits
 instance Binary Limits
 
 instance FromJSON Limits where
@@ -31,7 +31,7 @@ data RateLimit = RateLimit
     }
   deriving (Show, {- Data, -} Typeable, Eq, Ord, Generic)
 
-instance NFData RateLimit where rnf = genericRnf
+instance NFData RateLimit
 instance Binary RateLimit
 
 instance FromJSON RateLimit where

--- a/src/GitHub/Data/RateLimit.hs
+++ b/src/GitHub/Data/RateLimit.hs
@@ -13,7 +13,7 @@ data Limits = Limits
     , limitsRemaining :: !Int
     , limitsReset     :: !SystemTime
     }
-  deriving (Show, {- Data, -} Typeable, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance NFData Limits
 instance Binary Limits
@@ -29,7 +29,7 @@ data RateLimit = RateLimit
     , rateLimitSearch  :: Limits
     , rateLimitGraphQL :: Limits
     }
-  deriving (Show, {- Data, -} Typeable, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance NFData RateLimit
 instance Binary RateLimit

--- a/src/GitHub/Data/Reactions.hs
+++ b/src/GitHub/Data/Reactions.hs
@@ -13,7 +13,7 @@ data Reaction = Reaction
   , reactionContent :: !ReactionContent
   , reactionCreatedAt :: !UTCTime
   }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Reaction
 instance Binary Reaction
@@ -21,7 +21,7 @@ instance Binary Reaction
 data NewReaction = NewReaction
   { newReactionContent :: !ReactionContent
   }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewReaction
 instance Binary NewReaction
@@ -37,7 +37,7 @@ data ReactionContent
   | Hooray
   | Rocket
   | Eyes
-  deriving (Show, Data, Typeable, Eq, Ord, Enum, Bounded, Generic)
+  deriving (Show, Data, Eq, Ord, Enum, Bounded, Generic)
 
 instance NFData ReactionContent
 instance Binary ReactionContent

--- a/src/GitHub/Data/Reactions.hs
+++ b/src/GitHub/Data/Reactions.hs
@@ -15,7 +15,7 @@ data Reaction = Reaction
   }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Reaction where rnf = genericRnf
+instance NFData Reaction
 instance Binary Reaction
 
 data NewReaction = NewReaction
@@ -23,7 +23,7 @@ data NewReaction = NewReaction
   }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewReaction where rnf = genericRnf
+instance NFData NewReaction
 instance Binary NewReaction
 
 -- |
@@ -39,7 +39,7 @@ data ReactionContent
   | Eyes
   deriving (Show, Data, Typeable, Eq, Ord, Enum, Bounded, Generic)
 
-instance NFData ReactionContent where rnf = genericRnf
+instance NFData ReactionContent
 instance Binary ReactionContent
 
 -- JSON instances

--- a/src/GitHub/Data/Releases.hs
+++ b/src/GitHub/Data/Releases.hs
@@ -47,7 +47,7 @@ instance FromJSON Release where
         <*> o .: "author"
         <*> o .: "assets"
 
-instance NFData Release where rnf = genericRnf
+instance NFData Release
 instance Binary Release
 
 data ReleaseAsset = ReleaseAsset
@@ -81,5 +81,5 @@ instance FromJSON ReleaseAsset where
         <*> o .: "updated_at"
         <*> o .: "uploader"
 
-instance NFData ReleaseAsset where rnf = genericRnf
+instance NFData ReleaseAsset
 instance Binary ReleaseAsset

--- a/src/GitHub/Data/Releases.hs
+++ b/src/GitHub/Data/Releases.hs
@@ -25,7 +25,7 @@ data Release = Release
     , releaseAuthor          :: !SimpleUser
     , releaseAssets          :: !(Vector ReleaseAsset)
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance FromJSON Release where
     parseJSON = withObject "Event" $ \o -> Release
@@ -64,7 +64,7 @@ data ReleaseAsset = ReleaseAsset
     , releaseAssetUpdatedAt          :: !UTCTime
     , releaseAssetUploader           :: !SimpleUser
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance FromJSON ReleaseAsset where
     parseJSON = withObject "Event" $ \o -> ReleaseAsset

--- a/src/GitHub/Data/Repos.hs
+++ b/src/GitHub/Data/Repos.hs
@@ -55,7 +55,7 @@ data Repo = Repo
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Repo where rnf = genericRnf
+instance NFData Repo
 instance Binary Repo
 
 data CodeSearchRepo = CodeSearchRepo
@@ -90,7 +90,7 @@ data CodeSearchRepo = CodeSearchRepo
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData CodeSearchRepo where rnf = genericRnf
+instance NFData CodeSearchRepo
 instance Binary CodeSearchRepo
 
 -- | Repository permissions, as they relate to the authenticated user.
@@ -103,7 +103,7 @@ data RepoPermissions = RepoPermissions
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RepoPermissions where rnf = genericRnf
+instance NFData RepoPermissions
 instance Binary RepoPermissions
 
 data RepoRef = RepoRef
@@ -112,7 +112,7 @@ data RepoRef = RepoRef
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RepoRef where rnf = genericRnf
+instance NFData RepoRef
 instance Binary RepoRef
 
 data NewRepo = NewRepo
@@ -131,7 +131,7 @@ data NewRepo = NewRepo
     , newRepoAllowRebaseMerge  :: !(Maybe Bool)
     } deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
-instance NFData NewRepo where rnf = genericRnf
+instance NFData NewRepo
 instance Binary NewRepo
 
 newRepo :: Name Repo -> NewRepo
@@ -153,7 +153,7 @@ data EditRepo = EditRepo
     }
     deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
-instance NFData EditRepo where rnf = genericRnf
+instance NFData EditRepo
 instance Binary EditRepo
 
 -- | Filter the list of the user's repos using any of these constructors.
@@ -175,7 +175,7 @@ newtype Language = Language Text
 getLanguage :: Language -> Text
 getLanguage (Language l) = l
 
-instance NFData Language where rnf = genericRnf
+instance NFData Language
 instance Binary Language
 instance Hashable Language where
     hashWithSalt salt (Language l) = hashWithSalt salt l
@@ -190,7 +190,7 @@ data Contributor
     | AnonymousContributor !Int !Text
    deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Contributor where rnf = genericRnf
+instance NFData Contributor
 instance Binary Contributor
 
 contributorToSimpleUser :: Contributor -> Maybe SimpleUser
@@ -207,7 +207,7 @@ data CollaboratorPermission
     | CollaboratorPermissionNone
     deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
 
-instance NFData CollaboratorPermission where rnf = genericRnf
+instance NFData CollaboratorPermission
 instance Binary CollaboratorPermission
 
 -- | A collaborator and its permission on a repository.
@@ -216,7 +216,7 @@ data CollaboratorWithPermission
     = CollaboratorWithPermission SimpleUser CollaboratorPermission
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData CollaboratorWithPermission where rnf = genericRnf
+instance NFData CollaboratorWithPermission
 instance Binary CollaboratorWithPermission
 
 -- JSON instances

--- a/src/GitHub/Data/Repos.hs
+++ b/src/GitHub/Data/Repos.hs
@@ -53,7 +53,7 @@ data Repo = Repo
     , repoUpdatedAt       :: !(Maybe UTCTime)
     , repoPermissions     :: !(Maybe RepoPermissions) -- ^ Repository permissions as they relate to the authenticated user.
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Repo
 instance Binary Repo
@@ -88,7 +88,7 @@ data CodeSearchRepo = CodeSearchRepo
     , codeSearchRepoUpdatedAt       :: !(Maybe UTCTime)
     , codeSearchRepoPermissions     :: !(Maybe RepoPermissions) -- ^ Repository permissions as they relate to the authenticated user.
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData CodeSearchRepo
 instance Binary CodeSearchRepo
@@ -101,7 +101,7 @@ data RepoPermissions = RepoPermissions
     , repoPermissionPush :: !Bool
     , repoPermissionPull :: !Bool
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RepoPermissions
 instance Binary RepoPermissions
@@ -110,7 +110,7 @@ data RepoRef = RepoRef
     { repoRefOwner :: !SimpleOwner
     , repoRefRepo  :: !(Name Repo)
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RepoRef
 instance Binary RepoRef
@@ -129,7 +129,7 @@ data NewRepo = NewRepo
     , newRepoAllowSquashMerge  :: !(Maybe Bool)
     , newRepoAllowMergeCommit  :: !(Maybe Bool)
     , newRepoAllowRebaseMerge  :: !(Maybe Bool)
-    } deriving (Eq, Ord, Show, Data, Typeable, Generic)
+    } deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData NewRepo
 instance Binary NewRepo
@@ -151,7 +151,7 @@ data EditRepo = EditRepo
     , editAllowRebaseMerge :: !(Maybe Bool)
     , editArchived         :: !(Maybe Bool)
     }
-    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+    deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData EditRepo
 instance Binary EditRepo
@@ -163,14 +163,14 @@ data RepoPublicity
     | RepoPublicityPublic  -- ^ Only public repos.
     | RepoPublicityPrivate -- ^ Only private repos.
     | RepoPublicityMember  -- ^ Only repos to which the user is a member but not an owner.
-    deriving (Show, Eq, Ord, Enum, Bounded, Typeable, Data, Generic)
+    deriving (Show, Eq, Ord, Enum, Bounded, Data, Generic)
 
 -- | The value is the number of bytes of code written in that language.
 type Languages = HM.HashMap Language Int
 
 -- | A programming language.
 newtype Language = Language Text
-   deriving (Show, Data, Typeable, Eq, Ord, Generic)
+   deriving (Show, Data, Eq, Ord, Generic)
 
 getLanguage :: Language -> Text
 getLanguage (Language l) = l
@@ -188,7 +188,7 @@ data Contributor
     = KnownContributor !Int !URL !(Name User) !URL !(Id User) !Text
     -- | An unknown Github user with their number of contributions and recorded name.
     | AnonymousContributor !Int !Text
-   deriving (Show, Data, Typeable, Eq, Ord, Generic)
+   deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Contributor
 instance Binary Contributor
@@ -205,7 +205,7 @@ data CollaboratorPermission
     | CollaboratorPermissionWrite
     | CollaboratorPermissionRead
     | CollaboratorPermissionNone
-    deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Enum, Bounded, Eq, Ord, Generic)
 
 instance NFData CollaboratorPermission
 instance Binary CollaboratorPermission
@@ -214,7 +214,7 @@ instance Binary CollaboratorPermission
 -- See <https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level>
 data CollaboratorWithPermission
     = CollaboratorWithPermission SimpleUser CollaboratorPermission
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData CollaboratorWithPermission
 instance Binary CollaboratorWithPermission
@@ -381,7 +381,7 @@ instance FromJSONKey Language where
 data ArchiveFormat
     = ArchiveFormatTarball -- ^ ".tar.gz" format
     | ArchiveFormatZipball -- ^ ".zip" format
-    deriving (Show, Eq, Ord, Enum, Bounded, Typeable, Data, Generic)
+    deriving (Show, Eq, Ord, Enum, Bounded, Data, Generic)
 
 instance IsPathPart ArchiveFormat where
     toPathPart af = case af of

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -61,7 +61,7 @@ data CommandMethod
     | Patch
     | Put
     | Delete
-  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Data, Generic)
 
 instance Hashable CommandMethod
 
@@ -81,7 +81,7 @@ data FetchCount =
     FetchAtLeast !Word
     | FetchAll
     | FetchPage PageParams
-    deriving (Eq, Ord, Read, Show, Generic, Typeable)
+    deriving (Eq, Ord, Read, Show, Generic)
 
 
 -- | This instance is there mostly for 'fromInteger'.
@@ -111,7 +111,7 @@ data PageParams = PageParams {
     pageParamsPerPage :: Maybe Int
     , pageParamsPage :: Maybe Int
     }
-    deriving (Eq, Ord, Read, Show, Generic, Typeable)
+    deriving (Eq, Ord, Read, Show, Generic)
 
 instance Hashable PageParams
 instance Binary PageParams
@@ -129,7 +129,7 @@ data PageLinks = PageLinks {
     , pageLinksLast :: Maybe URI
     , pageLinksFirst :: Maybe URI
     }
-    deriving (Eq, Ord, Show, Generic, Typeable)
+    deriving (Eq, Ord, Show, Generic)
 
 instance NFData PageLinks
 
@@ -148,7 +148,7 @@ data MediaType a
     | MtStatus     -- ^ Parse status
     | MtUnit       -- ^ Always succeeds
     | MtPreview  a -- ^ Some other (preview) type; this is an extension point.
-  deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
+  deriving (Eq, Ord, Read, Show, Data, Generic)
 
 ------------------------------------------------------------------------------
 -- RW
@@ -160,7 +160,7 @@ data RW
     = RO  -- ^ /Read-only/, doesn't necessarily requires authentication
     | RA  -- ^ /Read authenticated/
     | RW  -- ^ /Read-write/, requires authentication
-  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Data, Generic)
 
 {-
 data SRO (rw :: RW) where
@@ -194,7 +194,6 @@ data GenRequest (mt :: MediaType *) (rw :: RW) a where
         -> Paths                   -- ^ path
         -> LBS.ByteString          -- ^ body
         -> GenRequest mt 'RW a
-  deriving (Typeable)
 
 -- | Most requests ask for @JSON@.
 type Request = GenRequest 'MtJSON

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -100,7 +100,7 @@ instance Num FetchCount where
 
 instance Hashable FetchCount
 instance Binary FetchCount
-instance NFData FetchCount where rnf = genericRnf
+instance NFData FetchCount
 
 -------------------------------------------------------------------------------
 -- PageParams
@@ -115,7 +115,7 @@ data PageParams = PageParams {
 
 instance Hashable PageParams
 instance Binary PageParams
-instance NFData PageParams where rnf = genericRnf
+instance NFData PageParams
 
 -------------------------------------------------------------------------------
 -- PageLinks
@@ -131,7 +131,7 @@ data PageLinks = PageLinks {
     }
     deriving (Eq, Ord, Show, Generic, Typeable)
 
-instance NFData PageLinks where rnf = genericRnf
+instance NFData PageLinks
 
 -------------------------------------------------------------------------------
 -- MediaType

--- a/src/GitHub/Data/Reviews.hs
+++ b/src/GitHub/Data/Reviews.hs
@@ -16,9 +16,7 @@ data ReviewState
     | ReviewStateChangesRequested
     deriving (Show, Enum, Bounded, Eq, Ord, Generic)
 
-instance NFData ReviewState where
-    rnf = genericRnf
-
+instance NFData ReviewState
 instance Binary ReviewState
 
 instance FromJSON ReviewState where
@@ -41,9 +39,7 @@ data Review = Review
     , reviewId :: !(Id Review)
     } deriving (Show, Generic)
 
-instance NFData Review where
-    rnf = genericRnf
-
+instance NFData Review
 instance Binary Review
 
 instance FromJSON Review where
@@ -74,9 +70,7 @@ data ReviewComment = ReviewComment
     , reviewCommentPullRequestUrl :: !URL
     } deriving (Show, Generic)
 
-instance NFData ReviewComment where
-    rnf = genericRnf
-
+instance NFData ReviewComment
 instance Binary ReviewComment
 
 instance FromJSON ReviewComment where

--- a/src/GitHub/Data/Search.hs
+++ b/src/GitHub/Data/Search.hs
@@ -15,7 +15,7 @@ data SearchResult' entities = SearchResult
 
 type SearchResult entity = SearchResult' (V.Vector entity)
 
-instance NFData entities => NFData (SearchResult' entities) where rnf = genericRnf
+instance NFData entities => NFData (SearchResult' entities)
 instance Binary entities => Binary (SearchResult' entities)
 
 instance (Monoid entities, FromJSON entities) => FromJSON (SearchResult' entities) where
@@ -40,7 +40,7 @@ data Code = Code
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Code where rnf = genericRnf
+instance NFData Code
 instance Binary Code
 
 instance FromJSON Code where

--- a/src/GitHub/Data/Search.hs
+++ b/src/GitHub/Data/Search.hs
@@ -11,7 +11,7 @@ data SearchResult' entities = SearchResult
     { searchResultTotalCount :: !Int
     , searchResultResults    :: !entities
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 type SearchResult entity = SearchResult' (V.Vector entity)
 
@@ -38,7 +38,7 @@ data Code = Code
     , codeHtmlUrl :: !URL
     , codeRepo    :: !CodeSearchRepo
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Code
 instance Binary Code

--- a/src/GitHub/Data/Statuses.hs
+++ b/src/GitHub/Data/Statuses.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
-{-# LANGUAGE OverloadedStrings  #-}
+
 module GitHub.Data.Statuses where
 
 import GitHub.Data.Definitions
@@ -21,7 +19,7 @@ data StatusState
     | StatusSuccess
     | StatusError
     | StatusFailure
-  deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Enum, Bounded, Eq, Ord, Generic)
 
 instance NFData StatusState
 instance Binary StatusState
@@ -52,7 +50,7 @@ data Status = Status
     , statusContext     :: !(Maybe Text)
     , statusCreator     :: !(Maybe SimpleUser)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance FromJSON Status where
   parseJSON = withObject "Status" $ \o -> Status
@@ -73,7 +71,7 @@ data NewStatus = NewStatus
     , newStatusDescription :: !(Maybe Text)
     , newStatusContext     :: !(Maybe Text)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData NewStatus
 instance Binary NewStatus
@@ -99,7 +97,7 @@ data CombinedStatus = CombinedStatus
     , combinedStatusCommitUrl  :: !URL
     , combinedStatusUrl        :: !URL
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance FromJSON CombinedStatus where
     parseJSON = withObject "CombinedStatus" $ \o -> CombinedStatus

--- a/src/GitHub/Data/Statuses.hs
+++ b/src/GitHub/Data/Statuses.hs
@@ -23,7 +23,7 @@ data StatusState
     | StatusFailure
   deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
 
-instance NFData StatusState where rnf = genericRnf
+instance NFData StatusState
 instance Binary StatusState
 
 instance FromJSON StatusState where
@@ -75,7 +75,7 @@ data NewStatus = NewStatus
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData NewStatus where rnf = genericRnf
+instance NFData NewStatus
 instance Binary NewStatus
 
 instance ToJSON NewStatus where

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -20,7 +20,7 @@ data Privacy
     | PrivacySecret
     deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
 
-instance NFData Privacy where rnf = genericRnf
+instance NFData Privacy
 instance Binary Privacy
 
 data Permission
@@ -29,7 +29,7 @@ data Permission
     | PermissionAdmin
     deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
 
-instance NFData Permission where rnf = genericRnf
+instance NFData Permission
 instance Binary Permission
 
 data AddTeamRepoPermission = AddTeamRepoPermission
@@ -37,7 +37,7 @@ data AddTeamRepoPermission = AddTeamRepoPermission
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData AddTeamRepoPermission where rnf = genericRnf
+instance NFData AddTeamRepoPermission
 instance Binary AddTeamRepoPermission
 
 data SimpleTeam = SimpleTeam
@@ -53,7 +53,7 @@ data SimpleTeam = SimpleTeam
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData SimpleTeam where rnf = genericRnf
+instance NFData SimpleTeam
 instance Binary SimpleTeam
 
 data Team = Team
@@ -72,7 +72,7 @@ data Team = Team
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData Team where rnf = genericRnf
+instance NFData Team
 instance Binary Team
 
 data CreateTeam = CreateTeam
@@ -84,7 +84,7 @@ data CreateTeam = CreateTeam
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData CreateTeam where rnf = genericRnf
+instance NFData CreateTeam
 instance Binary CreateTeam
 
 data EditTeam = EditTeam
@@ -95,7 +95,7 @@ data EditTeam = EditTeam
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData EditTeam where rnf = genericRnf
+instance NFData EditTeam
 instance Binary  EditTeam
 
 data Role
@@ -111,7 +111,7 @@ data ReqState
     | StateActive
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData ReqState where rnf = genericRnf
+instance NFData ReqState
 instance Binary ReqState
 
 data TeamMembership = TeamMembership
@@ -121,14 +121,14 @@ data TeamMembership = TeamMembership
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData TeamMembership where rnf = genericRnf
+instance NFData TeamMembership
 instance Binary TeamMembership
 
 data CreateTeamMembership = CreateTeamMembership {
   createTeamMembershipRole :: !Role
 } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData CreateTeamMembership where rnf = genericRnf
+instance NFData CreateTeamMembership
 instance Binary CreateTeamMembership
 
 -- JSON Instances

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
-{-# LANGUAGE OverloadedStrings  #-}
 
 module GitHub.Data.Teams where
 
@@ -18,7 +15,7 @@ import qualified Data.Text as T
 data Privacy
     = PrivacyClosed
     | PrivacySecret
-    deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Enum, Bounded, Eq, Ord, Generic)
 
 instance NFData Privacy
 instance Binary Privacy
@@ -27,7 +24,7 @@ data Permission
     = PermissionPull
     | PermissionPush
     | PermissionAdmin
-    deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Enum, Bounded, Eq, Ord, Generic)
 
 instance NFData Permission
 instance Binary Permission
@@ -35,7 +32,7 @@ instance Binary Permission
 data AddTeamRepoPermission = AddTeamRepoPermission
     { addTeamRepoPermission :: !Permission
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData AddTeamRepoPermission
 instance Binary AddTeamRepoPermission
@@ -51,7 +48,7 @@ data SimpleTeam = SimpleTeam
     , simpleTeamMembersUrl      :: !URL
     , simpleTeamRepositoriesUrl :: !URL
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData SimpleTeam
 instance Binary SimpleTeam
@@ -70,7 +67,7 @@ data Team = Team
     , teamReposCount      :: !Int
     , teamOrganization    :: !SimpleOrganization
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Team
 instance Binary Team
@@ -82,7 +79,7 @@ data CreateTeam = CreateTeam
     , createTeamPrivacy     :: !Privacy
     , createTeamPermission  :: !Permission
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData CreateTeam
 instance Binary CreateTeam
@@ -93,7 +90,7 @@ data EditTeam = EditTeam
     , editTeamPrivacy     :: !(Maybe Privacy)
     , editTeamPermission  :: !(Maybe Permission)
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData EditTeam
 instance Binary  EditTeam
@@ -101,7 +98,7 @@ instance Binary  EditTeam
 data Role
     = RoleMaintainer
     | RoleMember
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData Role
 instance Binary Role
@@ -109,7 +106,7 @@ instance Binary Role
 data ReqState
     = StatePending
     | StateActive
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData ReqState
 instance Binary ReqState
@@ -119,14 +116,14 @@ data TeamMembership = TeamMembership
     , teamMembershipRole     :: !Role
     , teamMembershipReqState :: !ReqState
     }
-    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+    deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData TeamMembership
 instance Binary TeamMembership
 
 data CreateTeamMembership = CreateTeamMembership {
   createTeamMembershipRole :: !Role
-} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+} deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData CreateTeamMembership
 instance Binary CreateTeamMembership
@@ -254,4 +251,4 @@ data TeamMemberRole
     = TeamMemberRoleAll         -- ^ all members of the team.
     | TeamMemberRoleMaintainer  -- ^ team maintainers
     | TeamMemberRoleMember      -- ^ normal members of the team.
-    deriving (Show, Eq, Ord, Enum, Bounded, Typeable, Data, Generic)
+    deriving (Show, Eq, Ord, Enum, Bounded, Data, Generic)

--- a/src/GitHub/Data/URL.hs
+++ b/src/GitHub/Data/URL.hs
@@ -15,7 +15,7 @@ newtype URL = URL Text
 getUrl :: URL -> Text
 getUrl (URL url) = url
 
-instance NFData URL where rnf = genericRnf
+instance NFData URL
 instance Binary URL
 
 instance ToJSON URL where

--- a/src/GitHub/Data/URL.hs
+++ b/src/GitHub/Data/URL.hs
@@ -10,7 +10,7 @@ import Prelude ()
 --
 -- /N.B./ syntactical validity is not verified.
 newtype URL = URL Text
-    deriving (Eq, Ord, Show, Generic, Typeable, Data)
+    deriving (Eq, Ord, Show, Generic, Data)
 
 getUrl :: URL -> Text
 getUrl (URL url) = url

--- a/src/GitHub/Data/Webhooks.hs
+++ b/src/GitHub/Data/Webhooks.hs
@@ -22,7 +22,7 @@ data RepoWebhook = RepoWebhook
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RepoWebhook where rnf = genericRnf
+instance NFData RepoWebhook
 instance Binary RepoWebhook
 
 -- | See <https://developer.github.com/webhooks/#events>.
@@ -87,7 +87,7 @@ data RepoWebhookEvent
     | WebhookWorkflowRun
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RepoWebhookEvent where rnf = genericRnf
+instance NFData RepoWebhookEvent
 instance Binary RepoWebhookEvent
 
 data RepoWebhookResponse = RepoWebhookResponse
@@ -97,7 +97,7 @@ data RepoWebhookResponse = RepoWebhookResponse
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData RepoWebhookResponse where rnf = genericRnf
+instance NFData RepoWebhookResponse
 instance Binary RepoWebhookResponse
 
 data PingEvent = PingEvent
@@ -107,7 +107,7 @@ data PingEvent = PingEvent
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
-instance NFData PingEvent where rnf = genericRnf
+instance NFData PingEvent
 instance Binary PingEvent
 
 data NewRepoWebhook = NewRepoWebhook
@@ -118,7 +118,7 @@ data NewRepoWebhook = NewRepoWebhook
     }
   deriving (Eq, Ord, Show, Typeable, Data, Generic)
 
-instance NFData NewRepoWebhook where rnf = genericRnf
+instance NFData NewRepoWebhook
 instance Binary NewRepoWebhook
 
 data EditRepoWebhook = EditRepoWebhook
@@ -130,7 +130,7 @@ data EditRepoWebhook = EditRepoWebhook
     }
   deriving (Eq, Ord, Show, Typeable, Data, Generic)
 
-instance NFData EditRepoWebhook where rnf = genericRnf
+instance NFData EditRepoWebhook
 instance Binary EditRepoWebhook
 
 -- JSON instances

--- a/src/GitHub/Data/Webhooks.hs
+++ b/src/GitHub/Data/Webhooks.hs
@@ -20,7 +20,7 @@ data RepoWebhook = RepoWebhook
     , repoWebhookUpdatedAt    :: !UTCTime
     , repoWebhookCreatedAt    :: !UTCTime
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RepoWebhook
 instance Binary RepoWebhook
@@ -85,7 +85,7 @@ data RepoWebhookEvent
     | WebhookWatchEvent
     | WebhookWorkflowDispatch
     | WebhookWorkflowRun
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RepoWebhookEvent
 instance Binary RepoWebhookEvent
@@ -95,7 +95,7 @@ data RepoWebhookResponse = RepoWebhookResponse
     , repoWebhookResponseStatus  :: !(Maybe Text)
     , repoWebhookResponseMessage :: !(Maybe Text)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData RepoWebhookResponse
 instance Binary RepoWebhookResponse
@@ -105,7 +105,7 @@ data PingEvent = PingEvent
     , pingEventHook   :: !RepoWebhook
     , pingEventHookId :: !(Id RepoWebhook)
     }
-  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+  deriving (Show, Data, Eq, Ord, Generic)
 
 instance NFData PingEvent
 instance Binary PingEvent
@@ -116,7 +116,7 @@ data NewRepoWebhook = NewRepoWebhook
     , newRepoWebhookEvents :: !(Maybe (Vector RepoWebhookEvent))
     , newRepoWebhookActive :: !(Maybe Bool)
     }
-  deriving (Eq, Ord, Show, Typeable, Data, Generic)
+  deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData NewRepoWebhook
 instance Binary NewRepoWebhook
@@ -128,7 +128,7 @@ data EditRepoWebhook = EditRepoWebhook
     , editRepoWebhookRemoveEvents :: !(Maybe (Vector RepoWebhookEvent))
     , editRepoWebhookActive       :: !(Maybe Bool)
     }
-  deriving (Eq, Ord, Show, Typeable, Data, Generic)
+  deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData EditRepoWebhook
 instance Binary EditRepoWebhook

--- a/src/GitHub/Internal/Prelude.hs
+++ b/src/GitHub/Internal/Prelude.hs
@@ -13,7 +13,7 @@ import Data.Aeson               as X
 import Data.Aeson.Types         as X (emptyObject, typeMismatch)
 import Data.Binary              as X (Binary)
 import Data.Binary.Instances    as X ()
-import Data.Data                as X (Data, Typeable)
+import Data.Data                as X (Data)
 import Data.Foldable            as X (toList)
 import Data.Hashable            as X (Hashable (..))
 import Data.HashMap.Strict      as X (HashMap)

--- a/src/GitHub/Internal/Prelude.hs
+++ b/src/GitHub/Internal/Prelude.hs
@@ -7,7 +7,6 @@ module GitHub.Internal.Prelude ( module X ) where
 
 import Control.Applicative      as X ((<|>))
 import Control.DeepSeq          as X (NFData (..))
-import Control.DeepSeq.Generics as X (genericRnf)
 import Data.Aeson               as X
        (FromJSON (..), Object, ToJSON (..), Value (..), encode, object,
        withObject, withText, (.!=), (.:), (.:?), (.=))


### PR DESCRIPTION
- **Drop obsolete dependency on deepseq-generics**
  Functionality is available from deepseq
  

- **Bump dependency lower bounds to at least Stackage LTS 10.0 (GHC 8.2.2)**
  

- **Remove unused dependency transformers-compat**
  

- **Remove obsolete `deriving Typeable`**
  

- **Bump to v0.30.0.1 and CHANGELOG, bump Haskell CI to 9.14 alpha1**
  
Candidate: https://hackage.haskell.org/package/github-0.30.0.1/candidate