### PR TITLE
v0.30.0.2: allow http-client-tls-0.4, bump, CHANGELOG

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250821
+# version: 0.19.20260128
 #
-# REGENDATA ("0.19.20250821",["--config=cabal.haskell-ci","github","cabal.project"])
+# REGENDATA ("0.19.20260128",["--config=cabal.haskell-ci","github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -32,14 +35,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.14.0.20250819
+          - compiler: ghc-9.14.1
             compilerKind: ghc
-            compilerVersion: 9.14.0.20250819
-            setup-method: ghcup-prerelease
+            compilerVersion: 9.14.1
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.10.3
+            compilerKind: ghc
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.2
@@ -126,21 +134,6 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup prerelease)
-        if: matrix.setup-method == 'ghcup-prerelease'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -151,7 +144,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -179,18 +172,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -214,14 +195,14 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: source
       - name: initial cabal.project for sdist
         run: |
           touch cabal.project
-          echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
-          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/samples" >> cabal.project ; fi
+          if [ $((HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80400 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/samples" >> cabal.project ; fi
           cat cabal.project
       - name: sdist
         run: |
@@ -240,16 +221,16 @@ jobs:
           rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
-          echo "packages: ${PKGDIR_github}" >> cabal.project
-          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "packages: ${PKGDIR_github_samples}" >> cabal.project ; fi
-          echo "package github" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
-          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
+          if [ $((HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then echo "packages: ${PKGDIR_github}" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80400 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: ${PKGDIR_github_samples}" >> cabal.project ; fi
+          if [ $((HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
+          if [ $((HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80400 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80400 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000 && HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then echo "package github" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000 && HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then echo "package github-samples" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           constraints:  github +openssl
           constraints:  github-samples +openssl
@@ -257,9 +238,6 @@ jobs:
           constraints:  operational -buildExamples
           optimization: False
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(github|github-samples)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -268,7 +246,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -285,13 +263,13 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+          if [ $((HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
-          cd ${PKGDIR_github} || false
-          ${CABAL} -vnormal check
-          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then cd ${PKGDIR_github_samples} || false ; fi
-          if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then cd ${PKGDIR_github} || false ; fi
+          if [ $((HCNUMVER < 91000 || HCNUMVER >= 91003)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER >= 80400 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then cd ${PKGDIR_github_samples} || false ; fi
+          if [ $((HCNUMVER >= 80400 && HCNUMVER < 91003 || HCNUMVER >= 91200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
@@ -301,7 +279,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Changes for 0.30.0.2
+
+_2026-03-12, Andreas Abel_
+
+- Fixed issue [#531](https://github.com/haskell-github/github/issues/531)
+  (Norfairking, PR [#532](https://github.com/haskell-github/github/pull/532)).
+- Allow `http-client-tls-0.4`.
+
+Tested with GHC 8.2 - 9.14.1.
+
 ## Changes for 0.30.0.1
 
 _2025-08-27, Andreas Abel_

--- a/github.cabal
+++ b/github.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               github
-version:            0.30.0.1
+version:            0.30.0.2
 synopsis:           Access to the GitHub API, v3.
 category:           Network
 description:
@@ -32,7 +32,7 @@ copyright:
 tested-with:
   GHC == 9.14.1
   GHC == 9.12.2
-  GHC == 9.10.2
+  GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8
@@ -223,7 +223,7 @@ library
 
   else
     build-depends:
-        http-client-tls  >=0.3.5.3 && <0.4
+        http-client-tls  >=0.3.5.3 && <0.5
       , tls              >=1.4.1
 
 test-suite github-test


### PR DESCRIPTION
Candidate: https://hackage.haskell.org/package/github-0.30.0.2/candidate

CI for GHC 9.14.1 fails:
> [__3] rejecting: base-4.22.0.0/installed-8900 (conflict: http-api-data => base>=4.12.0.0 && <4.22)
- https://github.com/fizruk/http-api-data/issues/152